### PR TITLE
Retry Payment feature for Payubiz.

### DIFF
--- a/src/app/checkout/checkout.module.ts
+++ b/src/app/checkout/checkout.module.ts
@@ -9,6 +9,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { routes } from './checkout.routes';
+import { OrderFailedComponent } from './order-failed/order-failed.component';
 
 @NgModule({
   imports: [
@@ -21,7 +22,7 @@ import { routes } from './checkout.routes';
     AddressModule,
     PaymentModule
   ],
-  declarations: [OrderSuccessComponent],
+  declarations: [OrderSuccessComponent, OrderFailedComponent],
   providers: [
     CheckoutActions
   ]

--- a/src/app/checkout/checkout.routes.ts
+++ b/src/app/checkout/checkout.routes.ts
@@ -2,11 +2,13 @@ import { OrderSuccessComponent } from './order-success/order-success.component';
 import { PaymentComponent } from './payment/payment.component';
 import { AddressComponent } from './address/address.component';
 import { CartComponent } from './cart/cart.component';
+import { OrderFailedComponent } from './order-failed/order-failed.component';
 
 export const routes = [
   { path: '', redirectTo: 'cart', pathMatch: 'full' },
   { path: 'cart', component: CartComponent },
   { path: 'address', component: AddressComponent },
   { path: 'payment', component: PaymentComponent },
-  { path: 'order-success', component: OrderSuccessComponent }
+  { path: 'order-success', component: OrderSuccessComponent },
+  { path: 'order-failed', component: OrderFailedComponent }
 ];

--- a/src/app/checkout/order-failed/order-failed.component.html
+++ b/src/app/checkout/order-failed/order-failed.component.html
@@ -1,0 +1,92 @@
+<div class="container" *ngIf="orderDetails">
+  <div class="col-12 thankyou thankyou1 shadow-sm mt-5 mb-3">
+    <h1>Sorry Your payment has been failed</h1>
+    <h5 *ngIf=errorReason>Reason: {{errorReason}}</h5>
+    <div class="float-left">
+      <i class="fa fa-close custom"></i>
+    </div>
+    <div>
+      <p class="w-75 text-success thankyoumsg"> Your order has been placed but payment is not processes.Retry payment to complete order.
+      </p>
+    </div>
+  </div>
+  <div class="order shadow-sm">
+    <div class="row">
+      <div class="col-12 col-sm-4 col-md-4 col-lg-4">
+        <h3>Order Details</h3>
+        <table>
+          <tr>
+            <td>Order ID:</td>
+            <td>{{orderDetails.number}}({{orderDetails.total_quantity}} Item(s))</td>
+          </tr>
+          <tr>
+            <td>Order Date:</td>
+            <td>{{orderDetails.created_at}}</td>
+          </tr>
+          <tr>
+            <td>Total Amount:</td>
+            <td>{{orderDetails.display_total}} through {{orderDetails.payments[0].payment_method.name}}</td>
+          </tr>
+          <tr *ngIf=orderDetails.payment_state>
+            <td>Payment Status:</td>
+            <td>
+              <b class="text-uppercase">
+                <button class="btn btn-primary" (click)="retryPayment(orderDetails)">
+                  Retry Payment
+                </button>
+              </b>
+
+            </td>
+          </tr>
+        </table>
+      </div>
+      <div class="col-12 col-sm-4 col-md-4 col-lg-4">
+        <h3>Delivery Address</h3>
+        <table>
+          <tr>
+            <td>Name: </td>
+            <td>{{orderDetails.ship_address.full_name}}</td>
+          </tr>
+          <tr>
+            <td>Address:</td>
+            <td>{{orderDetails.ship_address.address1}}, {{orderDetails.ship_address.address2}}, {{orderDetails.ship_address.city}}</td>
+          </tr>
+          <tr>
+            <td>Pincode:</td>
+            <td>{{orderDetails.ship_address.zipcode}}</td>
+          </tr>
+          <tr>
+            <td>Phone:</td>
+            <td>{{orderDetails.ship_address.phone}}</td>
+          </tr>
+          <tr>
+            <td>Email:</td>
+            <td>{{orderDetails.email}}</td>
+          </tr>
+        </table>
+      </div>
+      <div class="col-12 col-sm-4 col-md-4 col-lg-4">
+        <h3>Shipping</h3>
+        <div class="col-sm text-uppercase p-0">
+          <p>Shipping Status: </p>
+          <b>{{orderDetails.shipment_state}}</b>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="order-items shadow-sm mt-3 mb-3">
+    <div class="col-sm">
+      <h3>Item(s)</h3>
+      <div class="row" *ngFor="let line_item of orderDetails.line_items">
+        <a [routerLink]="['/', line_item.variant.slug]" class="col-sm col-3">
+          <img [src]="getProductImageUrl(line_item)">
+        </a>
+        <div class="col-sm col-9">
+          <p>{{line_item.variant.name}}</p>
+          <p>Qty: {{line_item.quantity}}</p>
+          <p>{{line_item.variant.options_text}}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/checkout/order-failed/order-failed.component.scss
+++ b/src/app/checkout/order-failed/order-failed.component.scss
@@ -1,0 +1,42 @@
+@import '../../shared/scss/selected_theme_variables';
+@media only screen and (min-width: 320px) and (max-width: 767px) {
+    .thankyou1 {
+        margin-top: 4em !important
+    }
+}
+
+.thankyou {
+    padding: 2em;
+    background-color: $gray-100;
+    h1 {
+        font-size: 1.7em;
+        text-transform: capitalize;
+    }
+    .fa-check-circle {
+        font-size: 40px;
+    }
+    .thankyoumsg {
+        padding: 0px 36px;
+        margin-left: 17px;
+        display: block;
+    }
+}
+
+.order {
+    @extend .thankyou;
+    h3 {
+        font-size: 1.7em;
+        color: $gray-600;
+    }
+    td {
+        font-size: 14px;
+    }
+}
+
+.order-items {
+    @extend .thankyou;
+    h3 {
+        font-size: 1.7em;
+        color: $gray-600;
+    }
+}

--- a/src/app/checkout/order-failed/order-failed.component.spec.ts
+++ b/src/app/checkout/order-failed/order-failed.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OrderFailedComponent } from './order-failed.component';
+
+describe('OrderFailedComponent', () => {
+  let component: OrderFailedComponent;
+  let fixture: ComponentFixture<OrderFailedComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [OrderFailedComponent]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OrderFailedComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/checkout/payment/payment-modes-list/payment-modes-list.component.ts
+++ b/src/app/checkout/payment/payment-modes-list/payment-modes-list.component.ts
@@ -21,7 +21,7 @@ import { ToastrService } from 'ngx-toastr';
 export class PaymentModesListComponent implements OnInit {
 
   @Input() paymentAmount: number;
-  @Input() orderNumber: number;
+  @Input() orderNumber: string;
   @Input() address: Address;
   isShippeble: boolean;
   showDummyCardInfo = environment.config.showDummyCardInfo;
@@ -89,7 +89,7 @@ export class PaymentModesListComponent implements OnInit {
   }
 
   makePaymentPayubiz() {
-    this.checkoutService.makePayment(this.paymentAmount, this.address)
+    this.checkoutService.makePayment(this.paymentAmount, this.address, this.orderNumber)
       .subscribe((response: any) => {
         response = response
         this.checkoutService.createNewPayment(this.selectedMode.id, this.paymentAmount).pipe(

--- a/src/app/core/services/checkout.service.ts
+++ b/src/app/core/services/checkout.service.ts
@@ -221,7 +221,7 @@ export class CheckoutService {
       .pipe(map(_ => this.changeOrderState().subscribe()));
   }
 
-  makePayment(paymentAmount: number, address: Address) {
+  makePayment(paymentAmount: number, address: any, orderNumber: string) {
     const payUbizSalt = environment.config.payuBizSalt;
     const payUbizKey = environment.config.payuBizKey;
     const successUrl = `${environment.apiEndpoint}payubiz/handle_payment`;
@@ -229,12 +229,12 @@ export class CheckoutService {
 
     const hashParams = {
       key: payUbizKey,
-      txnid: `${this.orderNumber}` + `${(Math.random().toString(36).substr(2, 9)).toUpperCase()}`,
+      txnid: `${orderNumber}` + `${(Math.random().toString(36).substr(2, 9)).toUpperCase()}`,
       amount: paymentAmount,
       productinfo: `${environment.appName}-Product`,
       firstname: address.firstname,
       email: JSON.parse(localStorage.getItem('user')).email,
-      udf1: `${this.orderNumber}`
+      udf1: `${orderNumber}`
     }
     // tslint:disable-next-line:max-line-length
     const paramsList = `${hashParams.key}|${hashParams.txnid}|${hashParams.amount}|${hashParams.productinfo}|${hashParams.firstname}|${hashParams.email}|${hashParams.udf1}||||||||||${payUbizSalt}`;


### PR DESCRIPTION
## Why?
* When Payment for an order failed due to user action or any other issue from payubiz. The user gets redirected to `order-failed` page with `order number` & `failed reason`. 
* User can retry the payment for same order.

## This change addresses the need by:

* Once user redirect on `order-failed` page. He can retry for payment for current order. After pressing `Retry Payment` button he redirected to payubiz agin for complete the payment for current order.

Note: UI is pending.

[delivers #159308185]
[Story](https://www.pivotaltracker.com/story/show/159308185)
