### PR TITLE
User profile address fixes.

### DIFF
--- a/src/app/user/components/addresses/add-edit-address/add-edit-address.component.html
+++ b/src/app/user/components/addresses/add-edit-address/add-edit-address.component.html
@@ -24,7 +24,7 @@
     <div class="form-group col-sm-6">
       <label> State </label>
       <select class="form-control" formControlName="state_name">
-        <option *ngIf="addressParams">{{addressParams.user.ship_address.state.name}}
+        <option *ngIf="stateName">{{stateName}}
           <option *ngFor="let state of states">{{state.name}}</option>
       </select>
     </div>

--- a/src/app/user/components/addresses/add-edit-address/add-edit-address.component.ts
+++ b/src/app/user/components/addresses/add-edit-address/add-edit-address.component.ts
@@ -15,6 +15,7 @@ export class AddEditAddressComponent implements OnInit {
   @Input() isEditAddrPressed: boolean;
   @Input() addressParams: any;
   @Output() isAddressEdited: EventEmitter<boolean> = new EventEmitter<boolean>();
+  @Input() stateName: any;
 
   constructor(private fb: FormBuilder,
     private addrService: AddressService,

--- a/src/app/user/components/addresses/addresses.component.html
+++ b/src/app/user/components/addresses/addresses.component.html
@@ -7,11 +7,19 @@
     <app-saved-address *ngIf="!isEditAddrPressed" [userDetails]="userDetails"></app-saved-address>
     <div *ngIf="isEditAddrPressed">
       <strong>Edit Address</strong>
-      <app-add-edit-address [isEditAddrPressed]="isEditAddrPressed" [addressParams]="buildAddressParams(userDetails)" (isAddressEdited)="addressEditedDone($event)"></app-add-edit-address>
+      <app-add-edit-address 
+        [isEditAddrPressed]="isEditAddrPressed" 
+        [addressParams]="buildAddressParams(userDetails)"
+        [stateName]="userDetails.ship_address.state.name"  
+        (isAddressEdited)="addressEditedDone($event)"></app-add-edit-address>
     </div>
   </div>
   <div *ngIf="userDetails?.ship_address===null">
     <strong>Add Address</strong>
-    <app-add-edit-address [isEditAddrPressed]="false" (isAddressEdited)="addressEditedDone($event)" [addressParams]="buildAddressParams(userDetails)"></app-add-edit-address>
+    <app-add-edit-address 
+      [isEditAddrPressed]="false" 
+      (isAddressEdited)="addressEditedDone($event)" 
+      [addressParams]="buildAddressParams(userDetails)"
+      [stateName]="null" ></app-add-edit-address>
   </div>
 </div>


### PR DESCRIPTION
## Why?
**Bug**
When user add new address it throws erros  for `state` name.

**Fixes**
Added `state` name to  address component. 

## This change addresses the need by:
User can add address without errors.

[delivers #159521418]
[Story](https://www.pivotaltracker.com/story/show/159521418)
