### PR TITLE
Ui/header scroll fix

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -2,6 +2,9 @@
 :host {
   min-height: 100vh;
   display: block;
+  .main-body {
+    margin-top: 50px;
+  }
 }
 
 .issearchopen :host /deep/ .main-body {

--- a/src/app/home/content/product-list/product-list.component.html
+++ b/src/app/home/content/product-list/product-list.component.html
@@ -30,12 +30,12 @@
       <pagination *ngIf="paginationData.total_count > paginationData.per_page" [totalItems]="paginationData.total_count" [itemsPerPage]="paginationData.per_page"
         [(ngModel)]="paginationData.current_page" (pageChanged)="pageChanged($event)" class="m-auto" [maxSize]="5"></pagination>
     </div>
-  
+
   </div>
 </div>
 
 <div class="row results-base m-0" *ngIf="isMobile">
-  <div class="col-12 product-base" *ngFor="let product of products | filter : selectedTaxonIds; trackBy: trackByFn" [style.margin]="getMargin()"
+  <div class="col-12 product-base" *ngFor="let product of products | filter : selectedTaxonIds" [style.margin]="getMargin()"
     itemscope itemtype="https://schema.org/Product">
     <a itemprop="url" [routerLink]="['/', product.slug]">
       <div class="row">
@@ -72,7 +72,7 @@
       <pagination *ngIf="paginationData.total_count > paginationData.per_page" [totalItems]="paginationData.total_count" [itemsPerPage]="paginationData.per_page"
         [(ngModel)]="paginationData.current_page" (pageChanged)="pageChanged($event)" class="m-auto" [maxSize]="3"></pagination>
     </div>
-  
+
   </div>
 </div>
 

--- a/src/app/layout/header/header.component.html
+++ b/src/app/layout/header/header.component.html
@@ -39,7 +39,7 @@
       </div>
     </div>
   </nav>
-  <nav class="navbar navbar-expand-lg">
+  <nav class="navbar navbar-expand-lg" id="sub-header" [ngClass]="{'hide-sub-header': isScrolled}">
     <div class="container">
       <div class="collapse navbar-collapse left-content-start">
         <app-categories-menu-dropdown [screenwidth]="screenwidth" [taxonomies]="taxonomies$ | async"></app-categories-menu-dropdown>

--- a/src/app/layout/header/header.component.scss
+++ b/src/app/layout/header/header.component.scss
@@ -1,17 +1,26 @@
 @import '../../shared/scss/selected_theme_variables';
 .navbar {
-  transition: all 500ms;
   padding: 0px;
   padding-top: 1rem;
-  &.page-scroll-header {
+  &#main{
+    transition: all 500ms;
     position: fixed;
-    z-index: 100;
     width: 100%;
+    z-index: 100;
   }
   &:not(#main),
   &.page-scroll-header {
     box-shadow: 0 8px 6px -8px $gray-900;
     z-index: 1;
+  }
+  &#sub-header {
+    transition: all 150ms;
+    width: 100%;
+    z-index: 1;
+    top: 50px;
+    &.hide-sub-header {
+      top: 0;
+    }
   }
 }
 

--- a/src/app/layout/header/header.component.ts
+++ b/src/app/layout/header/header.component.ts
@@ -9,7 +9,8 @@ import {
   OnInit,
   ChangeDetectionStrategy,
   ViewChild,
-  Input
+  Input,
+  HostListener
 } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { AppState } from '../../interfaces';
@@ -28,10 +29,6 @@ import { isPlatformBrowser } from '../../../../node_modules/@angular/common';
   selector: 'app-header',
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.scss'],
-  // tslint:disable-next-line:use-host-property-decorator
-  host: {
-    '(window:scroll)': 'updateHeader($event)'
-  },
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class HeaderComponent implements OnInit {
@@ -47,9 +44,11 @@ export class HeaderComponent implements OnInit {
   user$: Observable<any>;
   headerConfig = environment.config.header;
   isScrolled = false;
-  currPos: Number = 0;
-  startPos: Number = 0;
-  changePos: Number = 100;
+  scrollPos = {
+    currPos: 0,
+    startPos: 0,
+    changePos: 5,
+  };
   isMobile = false;
   screenwidth: any;
   modalRef: BsModalRef;
@@ -128,15 +127,19 @@ export class HeaderComponent implements OnInit {
     this.isModalShown = false;
   }
 
-  updateHeader(evt) {
-    if (this.screenwidth >= 1000) {
-      if (isPlatformBrowser(this.platformId)) {
-        this.currPos = (window.pageYOffset || evt.target.scrollTop) - (evt.target.clientTop || 0);
-      }
-      if (this.currPos >= this.changePos) {
-        this.isScrolled = true;
-      } else {
-        this.isScrolled = false;
+  @HostListener('window:scroll', ['$event'])
+  updateHeader($event) {
+    if (isPlatformBrowser(this.platformId)) {
+      if (this.screenwidth >= 1000) {
+        this.scrollPos.currPos = (window.pageYOffset || $event.target.scrollTop) - ($event.target.clientTop || 0);
+        if (
+          this.scrollPos.currPos >= this.scrollPos.changePos &&
+          window.pageYOffset >= 100
+        ) {
+          this.isScrolled = true;
+        } else {
+          this.isScrolled = false;
+        }
       }
     }
   }


### PR DESCRIPTION
### Why?
- Header UI flickers when scrolling.
- The subheader hides instantly creating a sudden movement of page upwards.

### This change addresses the need by:
- Making the headers fixed at the top, right from start.
- The subheader moves smoothly behind the main header after scroll.