### PR TITLE
Shipping preferences & other minor fixes

### DIFF
--- a/src/app/checkout/address/address.component.html
+++ b/src/app/checkout/address/address.component.html
@@ -8,16 +8,15 @@
 					</span>
 					<br>
 					<div class="reviewlink">
-					<strong (click)=changeAddress()>
-						Change
-					</strong>
-				</div>
+						<strong (click)=changeAddress()>
+							Change
+						</strong>
+					</div>
 				</div>
 				<app-delivery-address (click)="userAddressEdit(shipAddress)" [address]="shipAddress"></app-delivery-address>
 			</div>
-			<div class="right col-12 col-md-4 col-lg-4 m-0 ">
-				<app-delivery-options></app-delivery-options>
-				<button (click)="checkoutToPayment()" class="btn themebtnprimary">continue to payment</button>
+			<div class="right col-12 col-md-4 col-lg-4 m-0">
+				<app-delivery-options (onCheckoutToPayment)="checkoutToPayment()"></app-delivery-options>
 			</div>
 		</div>
 	</div>
@@ -28,16 +27,11 @@
 					+ ADD A NEW ADDRESS
 				</span>
 			</div>
-			<app-add-address [addressEdit]="null" 
-				*ngIf="isAddNewAddress" 
-				(cancelAddress)="cancelAddress($event)" 
-				[countries]="(this.countries$ | async)">
+			<app-add-address [addressEdit]="null" *ngIf="isAddNewAddress" (cancelAddress)="cancelAddress($event)" [countries]="(this.countries$ | async)">
 			</app-add-address>
 		</div>
 		<div class="left col-12 col-md-10 col-lg-10 m-auto border-right-0" *ngIf="userAddresses$ | async; let userAddresses">
-			<app-saved-address *ngIf="userAddresses.length > 0" 
-				[addressList]="userAddresses" 
-				(getSelectedAddress)="getSelectedAddress($event)">
+			<app-saved-address *ngIf="userAddresses.length > 0" [addressList]="userAddresses" (getSelectedAddress)="getSelectedAddress($event)">
 			</app-saved-address>
 		</div>
 	</div>

--- a/src/app/checkout/address/address.component.ts
+++ b/src/app/checkout/address/address.component.ts
@@ -2,18 +2,20 @@ import { getOrderId, getOrderNumber } from './../reducers/selectors';
 import { AppState } from './../../interfaces';
 import { Store } from '@ngrx/store';
 import { Address } from './../../core/models/address';
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, HostBinding } from '@angular/core';
 import { Subscription, Observable } from 'rxjs';
 import { UserActions } from '../../user/actions/user.actions';
 import { getUserAddressess, getCountries } from '../../user/reducers/selector';
 import { Country } from '../../core/models/country';
 import { CheckoutActions } from '../actions/checkout.actions';
 import { Router } from '@angular/router';
+import { fadeInAnimation } from '../../shared/animations/fade-in.animation';
 
 @Component({
   selector: 'app-address',
   templateUrl: './address.component.html',
   styleUrls: ['./address.component.scss'],
+  animations: [fadeInAnimation],
 })
 export class AddressComponent implements OnInit, OnDestroy {
   stateSub$: Subscription;
@@ -28,6 +30,9 @@ export class AddressComponent implements OnInit, OnDestroy {
   countries$: Observable<Country[]>;
   subscriptionList$: Array<Subscription> = [];
   orderNumber$: Observable<string>;
+  @HostBinding('@fadeInAnimation')
+  public animatePage = true;
+
 
   constructor(private store: Store<AppState>,
     private userActions: UserActions,

--- a/src/app/checkout/address/delivery-options/delivery-options.component.html
+++ b/src/app/checkout/address/delivery-options/delivery-options.component.html
@@ -30,4 +30,8 @@
       </div>
     </div>
   </div>
+  <button 
+    [disabled]="(orderState$ | async) !=='address'" 
+    (click)="checkoutToPayment()" 
+    class="btn themebtnprimary">continue to payment</button>
 </div>

--- a/src/app/checkout/address/delivery-options/delivery-options.component.ts
+++ b/src/app/checkout/address/delivery-options/delivery-options.component.ts
@@ -6,10 +6,11 @@ import {
   getShipTotal,
   getItemTotal,
   getAdjustmentTotal,
+  getOrderState,
 } from './../../reducers/selectors';
 import { Observable, Subscription } from 'rxjs';
 import { CheckoutService } from './../../../core/services/checkout.service';
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, EventEmitter, Output } from '@angular/core';
 import { environment } from '../../../../environments/environment';
 
 @Component({
@@ -18,6 +19,7 @@ import { environment } from '../../../../environments/environment';
   styleUrls: ['./delivery-options.component.scss']
 })
 export class DeliveryOptionsComponent implements OnInit, OnDestroy {
+  @Output() onCheckoutToPayment = new EventEmitter<boolean>();
   totalCartValue$: Observable<number>;
   totalCartItems$: Observable<number>;
   itemTotal$: Observable<number>;
@@ -26,6 +28,8 @@ export class DeliveryOptionsComponent implements OnInit, OnDestroy {
   currency = environment.config.currency_symbol;
   freeShippingAmount = environment.config.freeShippingAmount
   orderSub$: Subscription;
+  orderState$: Observable<string>;
+
 
   constructor(
     private checkoutService: CheckoutService,
@@ -39,11 +43,16 @@ export class DeliveryOptionsComponent implements OnInit, OnDestroy {
         this.shipTotal$ = this.store.select(getShipTotal);
         this.itemTotal$ = this.store.select(getItemTotal);
         this.adjustmentTotal$ = this.store.select(getAdjustmentTotal);
+        this.orderState$ = this.store.select(getOrderState);
       });
 
   }
 
   ngOnDestroy() {
     this.orderSub$.unsubscribe();
+  }
+
+  checkoutToPayment() {
+    this.onCheckoutToPayment.emit();
   }
 }

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -42,7 +42,7 @@ export class AuthService {
    * @memberof AuthService
    */
 
-  login({ email, password }): Observable<any> {
+  login({ email, password }): Observable<User> {
     const params = { data: { attributes: { 'email': email, 'password': password } } };
     return this.http.post<User>('api/v1/login', params).pipe(
       map(user => {
@@ -174,9 +174,13 @@ export class AuthService {
       return new HttpHeaders({
         'Content-Type': 'application/vnd.api+json',
         'Authorization': `Bearer ${this.getUserToken()}`,
+        'Accept': '*/*'
       });
     } else {
-      return new HttpHeaders({ 'Content-Type': 'application/vnd.api+json' });
+      return new HttpHeaders({
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': '*/*'
+      });
     }
 
   }

--- a/src/app/shared/animations/fade-in.animation.ts
+++ b/src/app/shared/animations/fade-in.animation.ts
@@ -1,0 +1,14 @@
+
+import { trigger, animate, transition, style } from '@angular/animations';
+export const fadeInAnimation =
+  trigger('fadeInAnimation', [
+    // route 'enter' transition
+    transition(':enter', [
+
+      // styles at start of transition
+      style({ opacity: 0 }),
+
+      // animation and styles at end of transition
+      animate('.3s', style({ opacity: 1 }))
+    ]),
+  ]);


### PR DESCRIPTION
## Why? 
**fixes**
* Unable to  add `shipping preferences` after selecting `address` for delivery.
* Added some UI fixes.
* Added `accept` in request headers.

## This change addresses the need by:

* After selecting address the `continew to payment` button will be remain desabled until order is in `address` state.
