### PR TITLE
Html sanitization for product description

### DIFF
--- a/src/app/product/components/product-detail-page/product-description/product-description.component.html
+++ b/src/app/product/components/product-detail-page/product-description/product-description.component.html
@@ -1,3 +1,3 @@
 <div itemprop="description" class="col-12">
-  <div innerHTML="{{description}}"> </div>
+  <div [innerHTML]="description | sanitizeHtml"> </div>
 </div>

--- a/src/app/shared/index.ts
+++ b/src/app/shared/index.ts
@@ -19,6 +19,7 @@ import { InnerIproductComponent } from './components/product-slider/inner-produc
 import { ZoomableDirective } from './directives/zoomable.directive';
 import { SavedAddressComponent } from './components/saved-address/saved-address.component';
 import { ReversePipe } from '../core/pipes/reverse.pipe';
+import { SanitizeHtmlPipe } from './pipes/sanitize-html.pipe';
 
 @NgModule({
   declarations: [
@@ -27,6 +28,7 @@ import { ReversePipe } from '../core/pipes/reverse.pipe';
     KeysPipe,
     HumanizePipe,
     ReversePipe,
+    SanitizeHtmlPipe,
     ZoomableDirective,
     ProductSliderComponent,
     InnerIproductComponent,
@@ -44,6 +46,7 @@ import { ReversePipe } from '../core/pipes/reverse.pipe';
     KeysPipe,
     HumanizePipe,
     ReversePipe,
+    SanitizeHtmlPipe,
     ZoomableDirective,
     ProductSliderComponent,
     SavedAddressComponent,

--- a/src/app/shared/pipes/sanitize-html.pipe.ts
+++ b/src/app/shared/pipes/sanitize-html.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+
+@Pipe({ name: 'sanitizeHtml' })
+
+/* DomSanitizer, a service of Angular helps to prevent attackers from injecting
+   malicious client-side scripts into web pages, which is often referred as
+   Cross-site Scripting or XSS.
+*/
+
+export class SanitizeHtmlPipe implements PipeTransform {
+
+  constructor(private _sanitizer: DomSanitizer) { }
+
+  transform(value: string): SafeHtml {
+    return this._sanitizer.bypassSecurityTrustHtml(value);
+  }
+}


### PR DESCRIPTION
## Why?
* Added Html sanitizer for stripped html content.

## This change addresses the need by:
* Product description will be look more beautiful as it will not omit html tags/content.