### PR TITLE
Enable search filter - Search Restructure - PHASE - 2

### DIFF
--- a/src/app/core/interceptors/reponse.interceptor.ts
+++ b/src/app/core/interceptors/reponse.interceptor.ts
@@ -18,7 +18,8 @@ export class ResponseInterceptor implements HttpInterceptor {
 
   }
 
-  private modifyBody({ body: body, url: url }) {
-    return body ? deserialize(body) : body;
+  private modifyBody({ body: body }) {
+    if (!body) { return body }
+    return { ...body, data: deserialize(body) };
   }
 }

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -44,8 +44,8 @@ export class AuthService {
 
   login({ email, password }): Observable<User> {
     const params = { data: { attributes: { 'email': email, 'password': password } } };
-    return this.http.post<User>('api/v1/login', params).pipe(
-      map(user => {
+    return this.http.post<{data: User}>('api/v1/login', params).pipe(
+      map(({data: user}) => {
         this.setTokenInLocalStorage(user, 'user');
         this.store.dispatch(this.actions.getCurrentUserSuccess(JSON.parse(localStorage.getItem('user'))));
         this.store.dispatch(this.actions.loginSuccess())
@@ -72,8 +72,8 @@ export class AuthService {
    */
   register(data: User): Observable<User> {
     const params = { data: { type: 'user', attributes: data } };
-    return this.http.post<User>('api/v1/register', params).pipe(
-      map(user => {
+    return this.http.post<{data: User}>('api/v1/register', params).pipe(
+      map(({data: user}) => {
         return user;
       }),
       tap(
@@ -231,6 +231,6 @@ export class AuthService {
   }
 
   getRatingCategories(): Observable<Array<RatingCategory>> {
-    return this.http.get<Array<RatingCategory>>(`api/v1/ratings/`);
+    return this.http.get<{data: Array<RatingCategory>}>(`api/v1/ratings/`).pipe(map(resp => resp.data));
   }
 }

--- a/src/app/core/services/product.service.ts
+++ b/src/app/core/services/product.service.ts
@@ -71,7 +71,7 @@ export class ProductService {
   getProducts(pageNumber: number): Observable<Array<Product>> {
     return this.http
       .get<{data: Array<Product>}>(
-        `api/v1/products?sort=date&page[limit]=20&page[offset]=${pageNumber}`
+        `api/v1/products?sort=date&rows=20&o=${(pageNumber - 1) * 20}`
       ).pipe(map(resp => resp.data));
   }
 
@@ -123,7 +123,7 @@ export class ProductService {
 
   getproductsByKeyword(keywords: any): Observable<Array<Product>> {
     return this.http
-      .get<{data: Array<Product>}>(`api/v1/products?page[limit]=20&page[offset]=1`, { params: keywords }).pipe(map(res => res.data));
+      .get<{data: Array<Product>}>(`api/v1/products?rows=20&o=1`, { params: keywords }).pipe(map(res => res.data));
   }
 
   getChildTaxons(taxonomyId: string, taxonId: string): Observable<Array<Taxonomy>> {

--- a/src/app/core/services/product.service.ts
+++ b/src/app/core/services/product.service.ts
@@ -39,17 +39,17 @@ export class ProductService {
    */
   getProduct(id: string): Observable<Product> {
     return this.http
-      .get<Product>(
+      .get<{data: Product}>(
         `api/v1/products/${id}?${+new Date()}`
-      )
+      ).pipe(map(resp => resp.data));
   }
 
   getProductReviews(productId: string): Observable<Array<Review>> {
-    return this.http.get<Array<Review>>(`api/v1/product/${productId}/reviews`);
+    return this.http.get<{data: Array<Review>}>(`api/v1/product/${productId}/reviews`).pipe(map(resp => resp.data));
   }
 
   getProductRatingSummery(productId: string): Observable<any> {
-    return this.http.get('api/v1/product/${productId}/rating-summary')
+    return this.http.get<any>('api/v1/product/${productId}/rating-summary').pipe(map(resp => resp.data));
   }
 
   /**
@@ -70,9 +70,9 @@ export class ProductService {
    */
   getProducts(pageNumber: number): Observable<Array<Product>> {
     return this.http
-      .get<Array<Product>>(
+      .get<{data: Array<Product>}>(
         `api/v1/products?sort=date&page[limit]=20&page[offset]=${pageNumber}`
-      )
+      ).pipe(map(resp => resp.data));
   }
 
   markAsFavorite(id: number): Observable<{}> {
@@ -85,93 +85,69 @@ export class ProductService {
 
   getFavoriteProducts(): Observable<Array<Product>> {
     return this.http
-      .get<{ data: CJsonApi[] }>(
+      .get<{ data: Array<Product> }>(
         `favorite_products.json?per_page=20&data_set=small`
       )
-      .pipe(
-        map(
-          (resp: any) => resp.data
-        )
-      );
+      .pipe(map(res => res.data));
   }
 
   getUserFavoriteProducts(): Observable<Array<Product>> {
     return this.http
-      .get<{ data: CJsonApi[] }>(
+      .get<{ data: Array<Product> }>(
         `spree/user_favorite_products.json?data_set=small`
       )
-      .pipe(
-        map(
-          resp => this.apiParser.parseArrayofObject(resp.data) as Array<Product>
-        )
-      );
+      .pipe(map(res => res.data));
   }
 
   getProductsByTaxon(id: string): Observable<any> {
     return this.http
-      .get<{ data: CJsonApi[]; pagination: Object }>(
+      .get<{ data: Array<Product> }>(
         `api/v1/taxons/products?${id}&per_page=20&data_set=small`
       )
-      .pipe(
-        map(resp => {
-          return {
-            pagination: resp.pagination,
-            products: this.apiParser.parseArrayofObject(resp.data) as Array<Product>
-          };
-        })
-      );
+      .pipe(map(res => res.data));
   }
 
   getProductsByTaxonNP(id: string): Observable<Array<Product>> {
     return this.http
-      .get<{ data: CJsonApi[] }>(
+      .get<{ data: Array<Product> }>(
         `api/v1/taxons/products?id=${id}&per_page=20&data_set=small`
       )
-      .pipe(
-        map(
-          (resp: any) => resp.data
-          // resp => this.apiParser.parseArrayofObject(resp.data) as Array<Product>
-        )
-      );
+      .pipe(map(res => res.data))
   }
 
   getTaxonByName(name: string): Observable<Array<Taxonomy>> {
-    return this.http.get<Array<Taxonomy>>(
+    return this.http.get<{data: Array<Taxonomy>}>(
       `api/v1/taxonomies?q[name_cont]=${name}&set=nested&per_page=2`
-    );
+    ).pipe(map(res => res.data));
   }
 
   getproductsByKeyword(keywords: any): Observable<Array<Product>> {
     return this.http
-      .get<Array<Product>>(`api/v1/products?page[limit]=20&page[offset]=1`, { params: keywords });
+      .get<{data: Array<Product>}>(`api/v1/products?page[limit]=20&page[offset]=1`, { params: keywords }).pipe(map(res => res.data));
   }
 
   getChildTaxons(taxonomyId: string, taxonId: string): Observable<Array<Taxonomy>> {
-    return this.http.get<Array<Taxonomy>>(
+    return this.http.get<{data: Array<Taxonomy>}>(
       `/api/v1/taxonomies/${taxonomyId}/taxons/${taxonId}`
-    );
+    ).pipe(map(res => res.data));
   }
 
   writeProductReview(params: Object): Observable<Review> {
-    return this.http.post<Review>(`api/v1/reviews`, params)
+    return this.http.post<{data: Review}>(`api/v1/reviews`, params).pipe(map(res => res.data));
   }
 
   getRelatedProducts(productId: any): Observable<Array<Product>> {
     return this.http
-      .get<{ data: CJsonApi[] }>(`api/products/${productId}/relations`)
-      .pipe(
-        map(
-          resp => this.apiParser.parseArrayofObject(resp.data) as Array<Product>
-        )
-      );
+      .get<{ data: Array<Product> }>(`api/products/${productId}/relations`)
+      .pipe(map(res => res.data));
   }
 
   getBrands(): Observable<Array<Brand>> {
-    return this.http.get<Array<Brand>>(`api/v1/brands`);
+    return this.http.get<{data: Array<Brand>}>(`api/v1/brands`).pipe(map(resp => resp.data));
   }
 
   getProductRatingOptions(ratingCategoryId: number): Observable<Array<RatingOption>>  {
-    return this.http.get<Array<RatingOption>>(`api/v1/ratings/${ratingCategoryId}`);
+    return this.http.get<{data: Array<RatingOption>}>(`api/v1/ratings/${ratingCategoryId}`).pipe(map(resp => resp.data));
   }
 
 }

--- a/src/app/landing/components/lp-brands/lp-brands.component.html
+++ b/src/app/landing/components/lp-brands/lp-brands.component.html
@@ -1,7 +1,7 @@
 <section *ngIf="brands">
-  <div class="slider-section">
+  <div class="slider-section mb-2">
     <div>
-      <a *ngIf="brands.length != 0" href=# class="section-title h3">100+ Brands in Stock!</a>
+      <a *ngIf="brands.length != 0" href=# class="section-title h3 position-relative">100+ Brands in Stock!</a>
     </div>
   </div>
   <div class="row m-0">

--- a/src/app/layout/header/components/header-search/header-search.component.ts
+++ b/src/app/layout/header/components/header-search/header-search.component.ts
@@ -51,7 +51,7 @@ export class HeaderSearchComponent implements OnInit {
   onSearch(keyword: string) {
     if (keyword !== '') {
       keyword = keyword.trim();
-      this.router.navigate(['/search'], { queryParams: { 'filter[name]': keyword } });
+      this.router.navigate(['/s'], { queryParams: { 'q': keyword } });
       this.setKeywordToLocalStorage(keyword);
     }
   }

--- a/src/app/modules/search/components/filter-summary-container/components/filter-summary-filter-list/filter-summary-filter-list.component.html
+++ b/src/app/modules/search/components/filter-summary-container/components/filter-summary-filter-list/filter-summary-filter-list.component.html
@@ -1,6 +1,8 @@
 <div class="col-12">
   <div class="row">
-    <app-filter-summary-filter class="border" [filter]="filter" *ngFor="let filter of filterList">
-    </app-filter-summary-filter>
+    <div *ngFor="let filter of filterList">
+      <app-filter-summary-filter class="border" [filter]="filter">
+      </app-filter-summary-filter>
+    </div>
   </div>
 </div>

--- a/src/app/modules/search/components/filter-summary-container/components/filter-summary-filter-list/filter-summary-filter-list.component.ts
+++ b/src/app/modules/search/components/filter-summary-container/components/filter-summary-filter-list/filter-summary-filter-list.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
+import { SearchAppliedParams } from '../../../../models/search-param';
 
 @Component({
   selector: 'app-filter-summary-filter-list',
@@ -6,15 +7,16 @@ import { Component, OnInit, Input } from '@angular/core';
   styleUrls: ['./filter-summary-filter-list.component.scss']
 })
 export class FilterSummaryFilterListComponent implements OnInit {
-  @Input() filterList: Array<{}> = [
-    {name: '20% discount and above'},
-    {name: 'Slim fit'},
-    {name: 'Dark colored'},
-  ];
+  @Input() appliedParams: SearchAppliedParams;
 
   constructor() { }
 
   ngOnInit() {
+  }
+
+  get filterList() {
+    return this.appliedParams.filters
+      .reduce((acc, filter) => acc.concat(filter.values), []);
   }
 
 }

--- a/src/app/modules/search/components/filter-summary-container/components/filter-summary-filter/filter-summary-filter.component.html
+++ b/src/app/modules/search/components/filter-summary-container/components/filter-summary-filter/filter-summary-filter.component.html
@@ -1,2 +1,2 @@
-<span>{{filter.name}}</span>
+<span>{{filter}}</span>
 <span class="ml-2" (click)="removeFilterClicked()">X</span>

--- a/src/app/modules/search/components/filter-summary-container/components/filter-summary-sort-by/filter-summary-sort-by.component.html
+++ b/src/app/modules/search/components/filter-summary-container/components/filter-summary-sort-by/filter-summary-sort-by.component.html
@@ -1,11 +1,11 @@
 <div class="btn-group float-right" dropdown triggers="mouseover">
   <button id="button-basic" dropdownToggle type="button" class="btn dropdown-toggle border text-secondary float-right text-left"
     aria-controls="dropdown-basic">
-    Sort by: <b>{{currentSort.name}}</b> <span class="caret"></span>
+    Sort by: <b class="px-2">{{currentSort.name}}</b> <span class="caret"></span>
   </button>
   <ul id="dropdown-basic" *dropdownMenu class="dropdown-menu" role="menu" aria-labelledby="button-basic">
     <li role="menuitem" *ngFor="let sortOption of sortConfig">
-      <a class="dropdown-item" (click)="sortOrder(sortOption.value)">{{sortOption.name}}</a>
+      <a class="dropdown-item" (click)="sortOrder(sortOption)">{{sortOption.name}}</a>
     </li>
   </ul>
 </div>

--- a/src/app/modules/search/components/filter-summary-container/components/filter-summary-sort-by/filter-summary-sort-by.component.scss
+++ b/src/app/modules/search/components/filter-summary-container/components/filter-summary-sort-by/filter-summary-sort-by.component.scss
@@ -1,0 +1,4 @@
+.btn-group{
+  position: relative;
+  bottom: 0.5rem;
+}

--- a/src/app/modules/search/components/filter-summary-container/components/filter-summary-sort-by/filter-summary-sort-by.component.ts
+++ b/src/app/modules/search/components/filter-summary-container/components/filter-summary-sort-by/filter-summary-sort-by.component.ts
@@ -22,8 +22,9 @@ export class FilterSummarySortByComponent implements OnInit {
     );
   }
 
-  sortOrder(value: string) {
-    this.selectedSort.emit({name: 'sort', value: value});
+  sortOrder(sortOption: SortFilter) {
+    this.currentSort = sortOption;
+    this.selectedSort.emit({name: 'sort', value: sortOption.value});
   }
 
 }

--- a/src/app/modules/search/components/filter-summary-container/filter-summary-container.component.html
+++ b/src/app/modules/search/components/filter-summary-container/filter-summary-container.component.html
@@ -1,6 +1,6 @@
-<section class="row">
+<section class="row px-4">
   <div class="col-8">
-    <app-filter-summary-filter-list></app-filter-summary-filter-list>
+    <app-filter-summary-filter-list [appliedParams]="appliedParams"></app-filter-summary-filter-list>
   </div>
   <app-filter-summary-sort-by class="col-4" (selectedSort)="filterUpdated($event)"></app-filter-summary-sort-by>
 </section>

--- a/src/app/modules/search/components/filter-summary-container/filter-summary-container.component.ts
+++ b/src/app/modules/search/components/filter-summary-container/filter-summary-container.component.ts
@@ -1,4 +1,4 @@
-import { SearchParam } from './../../models/search-param';
+import { SearchParam, SearchAppliedParams } from './../../models/search-param';
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({
@@ -7,7 +7,7 @@ import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
   styleUrls: ['./filter-summary-container.component.scss']
 })
 export class FilterSummaryContainerComponent implements OnInit {
-  @Input() appliedParams: SearchParam;
+  @Input() appliedParams: SearchAppliedParams;
   @Output() updatedFilters = new EventEmitter<SearchParam>();
 
   constructor() { }

--- a/src/app/modules/search/components/filter-summary-container/filter-summary-container.component.ts
+++ b/src/app/modules/search/components/filter-summary-container/filter-summary-container.component.ts
@@ -7,7 +7,7 @@ import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
   styleUrls: ['./filter-summary-container.component.scss']
 })
 export class FilterSummaryContainerComponent implements OnInit {
-  @Input() appliedFilters: SearchParam;
+  @Input() appliedParams: SearchParam;
   @Output() updatedFilters = new EventEmitter<SearchParam>();
 
   constructor() { }
@@ -16,7 +16,7 @@ export class FilterSummaryContainerComponent implements OnInit {
   }
 
   filterUpdated(filter: { name: any; value: any; }) {
-    this.updatedFilters.emit({...this.appliedFilters, [filter.name]: filter.value})
+    this.updatedFilters.emit({...this.appliedParams, [filter.name]: filter.value})
   }
 
 }

--- a/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.html
+++ b/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.html
@@ -2,7 +2,7 @@
   <small class="font-weight-bold pb-3 text-uppercase">{{filter.name}}</small>
   <li *ngFor="let item of filter.items | slice: skipCount" class="list-group-item border-0 p-0">
     <div class="custom-control custom-checkbox">
-      <input type="checkbox" class="custom-control-input" id="{{item.value}}">
+      <input type="checkbox" class="custom-control-input" id="{{item.value}}" [(ngModel)]="item.selected" (change)="selectedItem(item.value)">
       <label class="custom-control-label text-capitalize" for="{{item.value}}">{{item.name}}</label>
       <small class="text-secondary font-weight-light"> ( {{item.count}} ) </small>
     </div>

--- a/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.html
+++ b/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.html
@@ -1,8 +1,8 @@
 <ul class="list-group border border-left-0 border-bottom-0 py-3" *ngIf="showFilter">
   <small class="font-weight-bold pb-3 text-uppercase">{{filter.id}}</small>
-  <li *ngFor="let filterValue of filter.filterValues | slice: skipCount" class="list-group-item border-0 p-0">
+  <li *ngFor="let filterValue of filter.filterValues | slice: skipCount;" class="list-group-item border-0 p-0">
     <div class="custom-control custom-checkbox">
-      <input type="checkbox" class="custom-control-input" id="{{filterValue.id}}" (change)="selectedItem(filterValue.id)">
+      <input type="checkbox" class="custom-control-input" id="{{filterValue.id}}" [ngModel]="isSelected(filterValue.id)" (change)="selectedItem(filterValue.id)">
       <label class="custom-control-label text-capitalize" for="{{filterValue.id}}">{{filterValue.id}}</label>
       <small class="text-secondary font-weight-light"> ( {{filterValue.count}} ) </small>
     </div>

--- a/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.html
+++ b/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.html
@@ -1,9 +1,9 @@
 <ul class="list-group border border-left-0 border-bottom-0 py-3" *ngIf="showFilter">
   <small class="font-weight-bold pb-3 text-uppercase">{{filter.name}}</small>
-  <li *ngFor="let item of filter.items | slice: 1" class="list-group-item border-0 p-0">
+  <li *ngFor="let item of filter.items | slice: skipCount" class="list-group-item border-0 p-0">
     <div class="custom-control custom-checkbox">
       <input type="checkbox" class="custom-control-input" id="{{item.value}}">
-      <label class="custom-control-label" for="{{item.value}}">{{item.name}}</label>
+      <label class="custom-control-label text-capitalize" for="{{item.value}}">{{item.name}}</label>
       <small class="text-secondary font-weight-light"> ( {{item.count}} ) </small>
     </div>
   </li>

--- a/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.html
+++ b/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.html
@@ -1,6 +1,6 @@
 <ul class="list-group border border-left-0 border-bottom-0 py-3" *ngIf="filter.items.length">
   <small class="font-weight-bold pb-3 text-uppercase">{{filter.name}}</small>
-  <li *ngFor="let item of filter.items" class="list-group-item border-0 p-0">
+  <li *ngFor="let item of filter.items | slice:1" class="list-group-item border-0 p-0">
     <div class="custom-control custom-checkbox">
       <input type="checkbox" class="custom-control-input" id="{{item.value}}">
       <label class="custom-control-label" for="{{item.value}}">{{item.name}}</label>

--- a/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.html
+++ b/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.html
@@ -1,6 +1,6 @@
-<ul class="list-group border border-left-0 border-bottom-0 py-3" *ngIf="filter.items.length">
+<ul class="list-group border border-left-0 border-bottom-0 py-3" *ngIf="showFilter">
   <small class="font-weight-bold pb-3 text-uppercase">{{filter.name}}</small>
-  <li *ngFor="let item of filter.items | slice:1" class="list-group-item border-0 p-0">
+  <li *ngFor="let item of filter.items | slice: 1" class="list-group-item border-0 p-0">
     <div class="custom-control custom-checkbox">
       <input type="checkbox" class="custom-control-input" id="{{item.value}}">
       <label class="custom-control-label" for="{{item.value}}">{{item.name}}</label>

--- a/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.html
+++ b/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.html
@@ -1,9 +1,10 @@
-<ul class="list-group border border-left-0 border-bottom-0 py-3">
-  <small class="font-weight-bold pb-3 text-uppercase">{{filter.display_name}}</small>
-  <li *ngFor="let child of filter.items" class="list-group-item border-0 p-0">
+<ul class="list-group border border-left-0 border-bottom-0 py-3" *ngIf="filter.items.length">
+  <small class="font-weight-bold pb-3 text-uppercase">{{filter.name}}</small>
+  <li *ngFor="let item of filter.items" class="list-group-item border-0 p-0">
     <div class="custom-control custom-checkbox">
-      <input type="checkbox" class="custom-control-input" id="{{child.value}}">
-      <label class="custom-control-label font-weight-light" for="{{child.value}}">{{child.display_name}}</label>
+      <input type="checkbox" class="custom-control-input" id="{{item.value}}">
+      <label class="custom-control-label" for="{{item.value}}">{{item.name}}</label>
+      <small class="text-secondary font-weight-light"> ( {{item.count}} ) </small>
     </div>
   </li>
 </ul>

--- a/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.html
+++ b/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.html
@@ -1,10 +1,10 @@
 <ul class="list-group border border-left-0 border-bottom-0 py-3" *ngIf="showFilter">
-  <small class="font-weight-bold pb-3 text-uppercase">{{filter.name}}</small>
-  <li *ngFor="let item of filter.items | slice: skipCount" class="list-group-item border-0 p-0">
+  <small class="font-weight-bold pb-3 text-uppercase">{{filter.id}}</small>
+  <li *ngFor="let filterValue of filter.filterValues | slice: skipCount" class="list-group-item border-0 p-0">
     <div class="custom-control custom-checkbox">
-      <input type="checkbox" class="custom-control-input" id="{{item.value}}" [(ngModel)]="item.selected" (change)="selectedItem(item.value)">
-      <label class="custom-control-label text-capitalize" for="{{item.value}}">{{item.name}}</label>
-      <small class="text-secondary font-weight-light"> ( {{item.count}} ) </small>
+      <input type="checkbox" class="custom-control-input" id="{{filterValue.id}}" (change)="selectedItem(filterValue.id)">
+      <label class="custom-control-label text-capitalize" for="{{filterValue.id}}">{{filterValue.id}}</label>
+      <small class="text-secondary font-weight-light"> ( {{filterValue.count}} ) </small>
     </div>
   </li>
 </ul>

--- a/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.ts
+++ b/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.ts
@@ -1,3 +1,4 @@
+import { FilterAgg } from './../../../../models/search-param';
 import { Component, OnInit, Input, ChangeDetectionStrategy, Output, EventEmitter } from '@angular/core';
 
 @Component({
@@ -9,17 +10,17 @@ import { Component, OnInit, Input, ChangeDetectionStrategy, Output, EventEmitter
 export class MultiselectFilterComponent implements OnInit {
   @Input() filter: any;
   @Input() skipCount = 0;
-  @Output() filterClick = new EventEmitter();
+  @Output() filterClick = new EventEmitter<string>();
 
   constructor() { }
 
   ngOnInit() {
   }
 
-  get showFilter() { return this.filter.items.length > 0 }
+  get showFilter() { return this.filter.filterValues.length > 0 }
 
-  selectedItem(value: string | number) {
-    this.filterClick.emit(value);
+  selectedItem(id: string) {
+    this.filterClick.emit(id);
   }
 
 }

--- a/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.ts
+++ b/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, Input, ChangeDetectionStrategy, Output, EventEmitter } from '@angular/core';
 
 @Component({
   selector: 'app-multiselect-filter',
@@ -9,6 +9,7 @@ import { Component, OnInit, Input, ChangeDetectionStrategy } from '@angular/core
 export class MultiselectFilterComponent implements OnInit {
   @Input() filter: any;
   @Input() skipCount = 0;
+  @Output() filterClick = new EventEmitter();
 
   constructor() { }
 
@@ -16,5 +17,9 @@ export class MultiselectFilterComponent implements OnInit {
   }
 
   get showFilter() { return this.filter.items.length > 1 }
+
+  selectedItem(value: string | number) {
+    this.filterClick.emit(value);
+  }
 
 }

--- a/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.ts
+++ b/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.ts
@@ -1,16 +1,19 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, ChangeDetectionStrategy } from '@angular/core';
 
 @Component({
   selector: 'app-multiselect-filter',
   templateUrl: './multiselect-filter.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrls: ['./multiselect-filter.component.scss']
 })
 export class MultiselectFilterComponent implements OnInit {
-  @Input() filter;
+  @Input() filter: any;
 
   constructor() { }
 
   ngOnInit() {
   }
+
+  get showFilter() { return this.filter.items.length > 1 }
 
 }

--- a/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.ts
+++ b/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.ts
@@ -1,5 +1,6 @@
-import { FilterAgg } from './../../../../models/search-param';
+import { SearchFilter, FilterAgg, FilterValueAgg } from './../../../../models/search-param';
 import { Component, OnInit, Input, ChangeDetectionStrategy, Output, EventEmitter } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-multiselect-filter',
@@ -8,14 +9,16 @@ import { Component, OnInit, Input, ChangeDetectionStrategy, Output, EventEmitter
   styleUrls: ['./multiselect-filter.component.scss']
 })
 export class MultiselectFilterComponent implements OnInit {
-  @Input() filter: any;
+  @Input() filter: FilterAgg;
   @Input() skipCount = 0;
   @Output() filterClick = new EventEmitter<string>();
+  @Input() appliedFilters: Array<SearchFilter>;
 
-  constructor() { }
+  constructor(
+    private route: ActivatedRoute
+  ) { }
 
-  ngOnInit() {
-  }
+  ngOnInit() { }
 
   get showFilter() { return this.filter.filterValues.length > 0 }
 
@@ -23,4 +26,14 @@ export class MultiselectFilterComponent implements OnInit {
     this.filterClick.emit(id);
   }
 
+  isSelected(id: string) {
+    const currentFilter = this.appliedFilters
+      .find(filter => filter.id === this.filter.id);
+
+    if (currentFilter) {
+      return currentFilter.values.indexOf(id) !== -1;
+    } else {
+      return false
+    }
+  }
 }

--- a/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.ts
+++ b/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.ts
@@ -8,6 +8,7 @@ import { Component, OnInit, Input, ChangeDetectionStrategy } from '@angular/core
 })
 export class MultiselectFilterComponent implements OnInit {
   @Input() filter: any;
+  @Input() skipCount = 0;
 
   constructor() { }
 

--- a/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.ts
+++ b/src/app/modules/search/components/search-filters-container/components/multiselect-filter/multiselect-filter.component.ts
@@ -16,7 +16,7 @@ export class MultiselectFilterComponent implements OnInit {
   ngOnInit() {
   }
 
-  get showFilter() { return this.filter.items.length > 1 }
+  get showFilter() { return this.filter.items.length > 0 }
 
   selectedItem(value: string | number) {
     this.filterClick.emit(value);

--- a/src/app/modules/search/components/search-filters-container/components/single-selection-filter/single-selection-filter.component.html
+++ b/src/app/modules/search/components/search-filters-container/components/single-selection-filter/single-selection-filter.component.html
@@ -1,6 +1,6 @@
-<ul class="list-group border border-left-0 border-bottom-0 py-3" *ngIf="filter.items.length">
+<ul class="list-group border border-left-0 border-bottom-0 py-3" *ngIf="showFilter">
   <small class="font-weight-bold pb-3 text-uppercase">{{filter.name}}</small>
-  <li *ngFor="let item of filter.items | slice:1" class="list-group-item border-0 p-0">
+  <li *ngFor="let item of filter.items | slice: 1" class="list-group-item border-0 p-0">
     <div class="custom-control custom-radio">
       <input type="radio" class="custom-control-input" id="{{item.value}}">
       <label class="custom-control-label" for="{{item.value}}">{{item.name}}</label>

--- a/src/app/modules/search/components/search-filters-container/components/single-selection-filter/single-selection-filter.component.html
+++ b/src/app/modules/search/components/search-filters-container/components/single-selection-filter/single-selection-filter.component.html
@@ -1,9 +1,9 @@
 <ul class="list-group border border-left-0 border-bottom-0 py-3" *ngIf="showFilter">
   <small class="font-weight-bold pb-3 text-uppercase">{{filter.name}}</small>
-  <li *ngFor="let item of filter.items | slice: 1" class="list-group-item border-0 p-0">
+  <li *ngFor="let item of filter.items | slice: skipCount" class="list-group-item border-0 p-0">
     <div class="custom-control custom-radio">
       <input type="radio" class="custom-control-input" id="{{item.value}}">
-      <label class="custom-control-label" for="{{item.value}}">{{item.name}}</label>
+      <label class="custom-control-label text-capitalize" for="{{item.value}}">{{item.name}}</label>
       <small class="text-secondary font-weight-light"> ( {{item.count}} ) </small>
     </div>
   </li>

--- a/src/app/modules/search/components/search-filters-container/components/single-selection-filter/single-selection-filter.component.html
+++ b/src/app/modules/search/components/search-filters-container/components/single-selection-filter/single-selection-filter.component.html
@@ -1,9 +1,10 @@
-<ul class="list-group border border-left-0 border-bottom-0 py-3">
-  <small class="font-weight-bold pb-3 text-uppercase">{{filter.display_name}}</small>
-  <li *ngFor="let child of filter.children" class="list-group-item border-0 p-0">
+<ul class="list-group border border-left-0 border-bottom-0 py-3" *ngIf="filter.items.length">
+  <small class="font-weight-bold pb-3 text-uppercase">{{filter.name}}</small>
+  <li *ngFor="let item of filter.items | slice:1" class="list-group-item border-0 p-0">
     <div class="custom-control custom-radio">
-      <input type="radio" class="custom-control-input" id="{{child.value}}">
-      <label class="custom-control-label font-weight-light" for="{{child.value}}">{{child.display_name}}</label>
+      <input type="radio" class="custom-control-input" id="{{item.value}}">
+      <label class="custom-control-label" for="{{item.value}}">{{item.name}}</label>
+      <small class="text-secondary font-weight-light"> ( {{item.count}} ) </small>
     </div>
   </li>
 </ul>

--- a/src/app/modules/search/components/search-filters-container/components/single-selection-filter/single-selection-filter.component.ts
+++ b/src/app/modules/search/components/search-filters-container/components/single-selection-filter/single-selection-filter.component.ts
@@ -9,6 +9,7 @@ import { filter } from 'rxjs/operators';
 })
 export class SingleSelectionFilterComponent implements OnInit {
   @Input() filter: any;
+  @Input() skipCount = 0;
 
   constructor() { }
 

--- a/src/app/modules/search/components/search-filters-container/components/single-selection-filter/single-selection-filter.component.ts
+++ b/src/app/modules/search/components/search-filters-container/components/single-selection-filter/single-selection-filter.component.ts
@@ -1,17 +1,20 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, ChangeDetectionStrategy } from '@angular/core';
 import { filter } from 'rxjs/operators';
 
 @Component({
   selector: 'app-single-selection-filter',
   templateUrl: './single-selection-filter.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrls: ['./single-selection-filter.component.scss']
 })
 export class SingleSelectionFilterComponent implements OnInit {
-  @Input() filter;
+  @Input() filter: any;
 
   constructor() { }
 
   ngOnInit() {
   }
+
+  get showFilter() { return this.filter.items.length > 1 }
 
 }

--- a/src/app/modules/search/components/search-filters-container/components/single-selection-filter/single-selection-filter.component.ts
+++ b/src/app/modules/search/components/search-filters-container/components/single-selection-filter/single-selection-filter.component.ts
@@ -1,5 +1,5 @@
+import { MultiselectFilterComponent } from './../multiselect-filter/multiselect-filter.component';
 import { Component, OnInit, Input, ChangeDetectionStrategy } from '@angular/core';
-import { filter } from 'rxjs/operators';
 
 @Component({
   selector: 'app-single-selection-filter',
@@ -7,15 +7,5 @@ import { filter } from 'rxjs/operators';
   changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrls: ['./single-selection-filter.component.scss']
 })
-export class SingleSelectionFilterComponent implements OnInit {
-  @Input() filter: any;
-  @Input() skipCount = 0;
-
-  constructor() { }
-
-  ngOnInit() {
-  }
-
-  get showFilter() { return this.filter.items.length > 1 }
-
+export class SingleSelectionFilterComponent extends MultiselectFilterComponent {
 }

--- a/src/app/modules/search/components/search-filters-container/search-filters-container.component.html
+++ b/src/app/modules/search/components/search-filters-container/search-filters-container.component.html
@@ -4,7 +4,7 @@
     CLEAR ALL
   </a>
 </div>
-<app-multiselect-filter [filter]="categoryFilter"></app-multiselect-filter>
+<app-multiselect-filter [filter]="categoryFilter" skipCount="1"></app-multiselect-filter>
 <app-multiselect-filter [filter]="brandFilter"></app-multiselect-filter>
 <div *ngFor="let optionFilter of optionFilters">
   <app-multiselect-filter [filter]="optionFilter"></app-multiselect-filter>

--- a/src/app/modules/search/components/search-filters-container/search-filters-container.component.html
+++ b/src/app/modules/search/components/search-filters-container/search-filters-container.component.html
@@ -4,8 +4,8 @@
     CLEAR ALL
   </a>
 </div>
-<app-multiselect-filter [filter]="categoryFilter" skipCount="1"></app-multiselect-filter>
+<app-multiselect-filter [filter]="categoryFilter" skipCount="1" (filterClick)="multiFilterUpdated($event, 'categories')"></app-multiselect-filter>
 <app-multiselect-filter [filter]="brandFilter"></app-multiselect-filter>
 <div *ngFor="let optionFilter of optionFilters">
-  <app-multiselect-filter [filter]="optionFilter"></app-multiselect-filter>
+  <app-multiselect-filter [filter]="optionFilter" (filterClick)="multiOptionFilterUpdated($event, optionFilter.name)"></app-multiselect-filter>
 </div>

--- a/src/app/modules/search/components/search-filters-container/search-filters-container.component.html
+++ b/src/app/modules/search/components/search-filters-container/search-filters-container.component.html
@@ -4,7 +4,7 @@
     CLEAR ALL
   </a>
 </div>
-<app-single-selection-filter [filter]="categoryFilter"></app-single-selection-filter>
+<app-multiselect-filter [filter]="categoryFilter"></app-multiselect-filter>
 <app-multiselect-filter [filter]="brandFilter"></app-multiselect-filter>
 <div *ngFor="let optionFilter of optionFilters">
   <app-multiselect-filter [filter]="optionFilter"></app-multiselect-filter>

--- a/src/app/modules/search/components/search-filters-container/search-filters-container.component.html
+++ b/src/app/modules/search/components/search-filters-container/search-filters-container.component.html
@@ -4,8 +4,8 @@
     CLEAR ALL
   </a>
 </div>
-<app-multiselect-filter [filter]="categoryFilter" skipCount="1" (filterClick)="multiFilterUpdated($event, 'categories')"></app-multiselect-filter>
-<app-multiselect-filter [filter]="brandFilter"></app-multiselect-filter>
+<app-multiselect-filter [filter]="categoryFilter" skipCount="0" (filterClick)="multiFilterUpdated($event, 'categories')"></app-multiselect-filter>
+<app-multiselect-filter [filter]="brandFilter" (filterClick)="multiFilterUpdated($event, 'brands')"></app-multiselect-filter>
 <div *ngFor="let optionFilter of optionFilters">
   <app-multiselect-filter [filter]="optionFilter" (filterClick)="multiOptionFilterUpdated($event, optionFilter.name)"></app-multiselect-filter>
 </div>

--- a/src/app/modules/search/components/search-filters-container/search-filters-container.component.html
+++ b/src/app/modules/search/components/search-filters-container/search-filters-container.component.html
@@ -4,8 +4,6 @@
     CLEAR ALL
   </a>
 </div>
-<app-multiselect-filter [filter]="categoryFilter" skipCount="0" (filterClick)="multiFilterUpdated($event, 'Category')"></app-multiselect-filter>
-<app-multiselect-filter [filter]="brandFilter" (filterClick)="multiFilterUpdated($event, 'Brand')"></app-multiselect-filter>
-<div *ngFor="let optionFilter of optionFilters">
-  <app-multiselect-filter [filter]="optionFilter" (filterClick)="multiOptionFilterUpdated($event, optionFilter.name)"></app-multiselect-filter>
+<div *ngFor="let filter of primaryFilters">
+  <app-multiselect-filter [filter]="filter" (filterClick)="updateFilter($event, filter.id)"></app-multiselect-filter>
 </div>

--- a/src/app/modules/search/components/search-filters-container/search-filters-container.component.html
+++ b/src/app/modules/search/components/search-filters-container/search-filters-container.component.html
@@ -4,8 +4,8 @@
     CLEAR ALL
   </a>
 </div>
-<app-multiselect-filter [filter]="categoryFilter" skipCount="0" (filterClick)="multiFilterUpdated($event, 'categories')"></app-multiselect-filter>
-<app-multiselect-filter [filter]="brandFilter" (filterClick)="multiFilterUpdated($event, 'brands')"></app-multiselect-filter>
+<app-multiselect-filter [filter]="categoryFilter" skipCount="0" (filterClick)="multiFilterUpdated($event, 'Category')"></app-multiselect-filter>
+<app-multiselect-filter [filter]="brandFilter" (filterClick)="multiFilterUpdated($event, 'Brand')"></app-multiselect-filter>
 <div *ngFor="let optionFilter of optionFilters">
   <app-multiselect-filter [filter]="optionFilter" (filterClick)="multiOptionFilterUpdated($event, optionFilter.name)"></app-multiselect-filter>
 </div>

--- a/src/app/modules/search/components/search-filters-container/search-filters-container.component.html
+++ b/src/app/modules/search/components/search-filters-container/search-filters-container.component.html
@@ -5,5 +5,5 @@
   </a>
 </div>
 <div *ngFor="let filter of primaryFilters">
-  <app-multiselect-filter [filter]="filter" (filterClick)="updateFilter($event, filter.id)"></app-multiselect-filter>
+  <app-multiselect-filter [appliedFilters]="appliedParams.filters" [filter]="filter" (filterClick)="updateFilter($event, filter.id)"></app-multiselect-filter>
 </div>

--- a/src/app/modules/search/components/search-filters-container/search-filters-container.component.ts
+++ b/src/app/modules/search/components/search-filters-container/search-filters-container.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 
 @Component({
   selector: 'app-search-filters-container',
@@ -6,119 +6,54 @@ import { Component, OnInit } from '@angular/core';
   styles: []
 })
 export class SearchFiltersContainerComponent implements OnInit {
-  categoryFilter = {
-    'type': 'category',
-    'selection': 'single',
-    'display_name': 'Category',
-    'item': {
-      'id': 5,
-      'display_name': 'Men Clothing',
-      'value': 'men_clothing'
-    },
-    'children': [
-      {
-        'id': 7,
-        'display_name': 'Shirt',
-        'value': 'shirt'
-      },
-      {
-        'id': 8,
-        'display_name': 'Tshirt',
-        'value': 'tshirt'
-      },
-      {
-        'id': 9,
-        'display_name': 'Jeans',
-        'value': 'jeans'
-      }
-    ],
-    'path': [
-      {
-        'id': 1,
-        'display_name': 'Clothing',
-        'value': 'clothing'
-      },
-      {
-        'id': 2,
-        'display_name': 'Men Clothing',
-        'value': 'men_clothing'
-      }
-    ]
-  };
-
-  brandFilter = {
-    'type': 'brand',
-    'selection': 'multiple',
-    'display_name': 'Brands',
-    'items': [
-      {
-        'id': 1,
-        'display_name': 'Roadsters',
-        'value': 'roadster'
-      },
-      {
-        'id': 2,
-        'display_name': 'Jack & Jones',
-        'value': 'jack_and_jones'
-      },
-      {
-        'id': 3,
-        'display_name': 'Signature',
-        'value': 'signature'
-      }
-    ]
-  };
+  @Input() metaInfo: any;
 
   optionFilters = [
     {
-      'type': 'option',
-      'selection': 'multiple',
-      'display_name': 'Size',
+      'name': 'Size',
       'items': [
-         {
-            'id': 1,
-            'display_name': 'S',
-            'value': 'S'
-         },
-         {
-            'id': 2,
-            'display_name': 'M',
-            'value': 'M'
-         },
-         {
-            'id': 3,
-            'display_name': 'L',
-            'value': 'L'
-         },
-         {
-            'id': 4,
-            'display_name': 'X',
-            'value': 'X'
-         }
+        {
+          'count': 1,
+          'name': 'S',
+          'value': 'S'
+        },
+        {
+          'count': 2,
+          'name': 'M',
+          'value': 'M'
+        },
+        {
+          'count': 3,
+          'name': 'L',
+          'value': 'L'
+        },
+        {
+          'count': 4,
+          'name': 'X',
+          'value': 'X'
+        }
       ]
-   },
-   {
-    'type': 'option',
-    'selection': 'multiple',
-    'display_name': 'Material',
-    'items': [
-       {
-          'id': 1,
-          'display_name': 'Cotton',
+    },
+    {
+      'name': 'Material',
+      'items': [
+        {
+          'count': 1,
+          'name': 'Cotton',
           'value': 'cotton'
-       },
-       {
-          'id': 2,
-          'display_name': 'Crepe',
+        },
+        {
+          'count': 2,
+          'name': 'Crepe',
           'value': 'crepe'
-       },
-       {
-          'id': 3,
-          'display_name': 'Silk',
+        },
+        {
+          'count': 3,
+          'name': 'Silk',
           'value': 'silk'
-       }
-    ]
- }
+        }
+      ]
+    }
   ];
 
   constructor() { }
@@ -127,6 +62,45 @@ export class SearchFiltersContainerComponent implements OnInit {
   }
 
   clearSearchFilters() {
+  }
+
+  get categoryFilter() {
+    const filter = {
+      name: 'Category',
+      items: []
+    };
+
+    if (!this.metaInfo) { return filter };
+
+    const { aggregations: { categories: { taxon: { buckets: categories } } } } = this.metaInfo;
+    return {
+      ...filter,
+      items: categories.map(this.formatFilter)
+    };
+  }
+
+  get brandFilter() {
+    const filter = {
+      name: 'Brand',
+      items: []
+    };
+
+    if (!this.metaInfo) { return filter };
+
+    const { aggregations: { brand: { buckets: brands } } } = this.metaInfo;
+    return {
+      ...filter,
+      items: brands.map(this.formatFilter)
+    };
+  }
+
+  private formatFilter(filter) {
+    const [id, name] = filter.key.split('|');
+    return {
+      value: id,
+      name: name,
+      count: filter.doc_count
+    };
   }
 
 }

--- a/src/app/modules/search/components/search-filters-container/search-filters-container.component.ts
+++ b/src/app/modules/search/components/search-filters-container/search-filters-container.component.ts
@@ -94,7 +94,7 @@ export class SearchFiltersContainerComponent implements OnInit {
     const if_exists = filterValues.find((val: any) => val === value);
     filterValues = filterValues.filter((val: any) => val !== value);
 
-    this.selectedAggregation.emit({ [filterName]: this.metaInfo.aggregations[filterName] });
+    this.selectedAggregation.emit({ [filterName]: this.metaInfo.aggregations.filters[filterName] });
 
     this.filterUpdated.emit(
       Object.assign(

--- a/src/app/modules/search/components/search-filters-container/search-filters-container.component.ts
+++ b/src/app/modules/search/components/search-filters-container/search-filters-container.component.ts
@@ -103,10 +103,10 @@ export class SearchFiltersContainerComponent implements OnInit {
     );
   }
 
-  multiOptionFilterUpdated(value: any, filterName: string) {
+  multiOptionFilterUpdated(value: string, filterName: string) {
     let filterOptions = this.appliedFilters.filter_options || [];
     const selectedFilterOption = filterOptions.find(option => option.name === filterName) || { value: [] };
-    const if_exists = selectedFilterOption.value.find((ov: any) => ov === value);
+    const if_exists = selectedFilterOption.value.find(ov => ov === value);
     const selectedFilterOptionValues = selectedFilterOption.value.filter(ov => ov !== value)
     filterOptions = filterOptions.filter(fo => fo.name !== filterName);
 

--- a/src/app/modules/search/components/search-filters-container/search-filters-container.component.ts
+++ b/src/app/modules/search/components/search-filters-container/search-filters-container.component.ts
@@ -1,4 +1,4 @@
-import { SearchFilter } from './../../models/search-param';
+import { SearchFilter, FilterAgg } from './../../models/search-param';
 import { Component, OnInit, Input, ChangeDetectionStrategy, Output, EventEmitter } from '@angular/core';
 import { SearchAppliedParams } from '../../models/search-param';
 
@@ -9,7 +9,11 @@ import { SearchAppliedParams } from '../../models/search-param';
   styles: []
 })
 export class SearchFiltersContainerComponent implements OnInit {
-  @Input() metaInfo: any;
+  @Input() metaInfo: {
+    aggregations: {
+      filters: Array<FilterAgg>
+    }
+  };
   @Input() appliedParams: SearchAppliedParams;
   @Output() filterCleared = new EventEmitter();
   @Output() filterUpdated = new EventEmitter();

--- a/src/app/modules/search/components/search-results-container/components/search-result-item/search-result-item.component.scss
+++ b/src/app/modules/search/components/search-results-container/components/search-result-item/search-result-item.component.scss
@@ -11,6 +11,8 @@ picture {
   height: 280px;
   img {
     height: 100%;
+    filter: drop-shadow(0 0 33px $pink);
+    -webkit-filter: drop-shadow(0 0 33px $pink);
   }
 }
 

--- a/src/app/modules/search/components/search-results-container/components/search-result-list/search-result-list.component.html
+++ b/src/app/modules/search/components/search-results-container/components/search-result-list/search-result-list.component.html
@@ -1,4 +1,4 @@
 <div class="row justify-content-between">
-  <app-search-result-item class="col mb-5 mx-1 p-0" [product]="product" *ngFor="let product of searchResults; trackBy:product?.id"></app-search-result-item>
+  <app-search-result-item class="col mb-5 mx-1 p-0" [product]="product" *ngFor="let product of searchResults; trackBy:trackBy"></app-search-result-item>
   <div class="results-li-dummy col mb-5 mx-1" *ngFor="let _ of dummyResults"></div>
 </div>

--- a/src/app/modules/search/components/search-results-container/components/search-result-list/search-result-list.component.html
+++ b/src/app/modules/search/components/search-results-container/components/search-result-list/search-result-list.component.html
@@ -1,4 +1,4 @@
 <div class="row justify-content-between">
-  <app-search-result-item class="col mb-5 mx-1 p-0" [product]="product" *ngFor="let product of searchResults; trackBy:trackBy"></app-search-result-item>
+  <app-search-result-item class="col mb-5 mx-1 p-0" [product]="product" *ngFor="let product of searchResults;"></app-search-result-item>
   <div class="results-li-dummy col mb-5 mx-1" *ngFor="let _ of dummyResults"></div>
 </div>

--- a/src/app/modules/search/components/search-results-container/components/search-result-list/search-result-list.component.html
+++ b/src/app/modules/search/components/search-results-container/components/search-result-list/search-result-list.component.html
@@ -1,4 +1,4 @@
 <div class="row justify-content-between">
-  <app-search-result-item class="col mb-5 mx-3 p-0" [product]="product" *ngFor="let product of searchResults"></app-search-result-item>
-  <div class="results-li-dummy col mb-5 mx-3" *ngFor="let _ of dummyResults"></div>
+  <app-search-result-item class="col mb-5 mx-2 p-0" [product]="product" *ngFor="let product of searchResults"></app-search-result-item>
+  <div class="results-li-dummy col mb-5 mx-2" *ngFor="let _ of dummyResults"></div>
 </div>

--- a/src/app/modules/search/components/search-results-container/components/search-result-list/search-result-list.component.html
+++ b/src/app/modules/search/components/search-results-container/components/search-result-list/search-result-list.component.html
@@ -1,4 +1,4 @@
-<div class="row">
-  <app-search-result-item class="col mb-5 mx-auto p-0" [product]="product" *ngFor="let product of searchResults"></app-search-result-item>
-  <div class="results-li-dummy col mb-5 mx-auto" *ngFor="let _ of dummyResults"></div>
+<div class="row justify-content-between">
+  <app-search-result-item class="col mb-5 mx-3 p-0" [product]="product" *ngFor="let product of searchResults"></app-search-result-item>
+  <div class="results-li-dummy col mb-5 mx-3" *ngFor="let _ of dummyResults"></div>
 </div>

--- a/src/app/modules/search/components/search-results-container/components/search-result-list/search-result-list.component.html
+++ b/src/app/modules/search/components/search-results-container/components/search-result-list/search-result-list.component.html
@@ -1,4 +1,4 @@
 <div class="row justify-content-between">
-  <app-search-result-item class="col mb-5 mx-2 p-0" [product]="product" *ngFor="let product of searchResults"></app-search-result-item>
-  <div class="results-li-dummy col mb-5 mx-2" *ngFor="let _ of dummyResults"></div>
+  <app-search-result-item class="col mb-5 mx-1 p-0" [product]="product" *ngFor="let product of searchResults"></app-search-result-item>
+  <div class="results-li-dummy col mb-5 mx-1" *ngFor="let _ of dummyResults"></div>
 </div>

--- a/src/app/modules/search/components/search-results-container/components/search-result-list/search-result-list.component.html
+++ b/src/app/modules/search/components/search-results-container/components/search-result-list/search-result-list.component.html
@@ -1,4 +1,4 @@
 <div class="row justify-content-between">
-  <app-search-result-item class="col mb-5 mx-1 p-0" [product]="product" *ngFor="let product of searchResults"></app-search-result-item>
+  <app-search-result-item class="col mb-5 mx-1 p-0" [product]="product" *ngFor="let product of searchResults; trackBy:product?.id"></app-search-result-item>
   <div class="results-li-dummy col mb-5 mx-1" *ngFor="let _ of dummyResults"></div>
 </div>

--- a/src/app/modules/search/components/search-results-container/components/search-result-list/search-result-list.component.ts
+++ b/src/app/modules/search/components/search-results-container/components/search-result-list/search-result-list.component.ts
@@ -14,8 +14,4 @@ export class SearchResultListComponent implements OnInit {
 
   ngOnInit() {
   }
-
-  trackBy(product) {
-    return product.id
-  }
 }

--- a/src/app/modules/search/components/search-results-container/components/search-result-list/search-result-list.component.ts
+++ b/src/app/modules/search/components/search-results-container/components/search-result-list/search-result-list.component.ts
@@ -15,4 +15,7 @@ export class SearchResultListComponent implements OnInit {
   ngOnInit() {
   }
 
+  trackBy(product) {
+    return product.id
+  }
 }

--- a/src/app/modules/search/components/search-results-container/search-results-container.component.html
+++ b/src/app/modules/search/components/search-results-container/search-results-container.component.html
@@ -1,3 +1,3 @@
 <section class="row">
-  <app-search-result-list [searchResults]="searchResults" class="col-12 my-2 py-3"></app-search-result-list>
+  <app-search-result-list [searchResults]="searchResults" class="col-12 my-2 py-3 px-5"></app-search-result-list>
 </section>

--- a/src/app/modules/search/components/search-title-container/search-title-container.component.html
+++ b/src/app/modules/search/components/search-title-container/search-title-container.component.html
@@ -1,4 +1,4 @@
 <h1 class="h6">
-  <div class="font-weight-bold d-inline">{{title}}</div>
+  <div class="font-weight-bold d-inline text-capitalize">{{title}}</div>
   <app-search-title-count class="text-secondary" [count]="metaInfo?.total"></app-search-title-count>
 </h1>

--- a/src/app/modules/search/components/search-title-container/search-title-container.component.html
+++ b/src/app/modules/search/components/search-title-container/search-title-container.component.html
@@ -1,4 +1,4 @@
 <h1 class="h6">
-  <div class="font-weight-bold d-inline">{{title}}</div>
-  <app-search-title-count class="text-secondary" [count]="count"></app-search-title-count>
+  <div class="font-weight-bold d-inline">Searching</div>
+  <app-search-title-count class="text-secondary" [count]="metaInfo?.total"></app-search-title-count>
 </h1>

--- a/src/app/modules/search/components/search-title-container/search-title-container.component.html
+++ b/src/app/modules/search/components/search-title-container/search-title-container.component.html
@@ -1,4 +1,4 @@
 <h1 class="h6">
-  <div class="font-weight-bold d-inline">Searching</div>
+  <div class="font-weight-bold d-inline">{{title}}</div>
   <app-search-title-count class="text-secondary" [count]="metaInfo?.total"></app-search-title-count>
 </h1>

--- a/src/app/modules/search/components/search-title-container/search-title-container.component.ts
+++ b/src/app/modules/search/components/search-title-container/search-title-container.component.ts
@@ -6,7 +6,8 @@ import { Component, OnInit, Input } from '@angular/core';
   styleUrls: ['./search-title-container.component.scss']
 })
 export class SearchTitleContainerComponent implements OnInit {
-  @Input() metaInfo;
+  @Input() title = 'Placeholder';
+  @Input() metaInfo: any;
 
   constructor() { }
 

--- a/src/app/modules/search/components/search-title-container/search-title-container.component.ts
+++ b/src/app/modules/search/components/search-title-container/search-title-container.component.ts
@@ -6,8 +6,7 @@ import { Component, OnInit, Input } from '@angular/core';
   styleUrls: ['./search-title-container.component.scss']
 })
 export class SearchTitleContainerComponent implements OnInit {
-  @Input() title: String = 'T-shirts For Men & Women';
-  @Input() count: Number = 0;
+  @Input() metaInfo;
 
   constructor() { }
 

--- a/src/app/modules/search/guards/search-resolver.ts
+++ b/src/app/modules/search/guards/search-resolver.ts
@@ -17,12 +17,8 @@ export class SearchResolver implements Resolve<any> {
   ) { }
 
   resolve(route: ActivatedRouteSnapshot, _state: RouterStateSnapshot): Observable<any> {
-    const query = route.queryParams['q'];
-    const appliedFilters = {
-      ...this.appliedFilters,
-      q: query
-    };
-    return this.searchingService.search(appliedFilters).pipe(
+    const queryParams = this.searchingService.convertToAPISearchParams(route.queryParams);
+    return this.searchingService.search(queryParams).pipe(
       catchError(_ => {
         this.toastrService.error('', 'Bad search query');
         this.router.navigate(['']);

--- a/src/app/modules/search/guards/search-resolver.ts
+++ b/src/app/modules/search/guards/search-resolver.ts
@@ -1,0 +1,33 @@
+import { SearchParam } from './../models/search-param';
+import { SearchingService } from './../services/searching.service';
+import { ToastrService } from 'ngx-toastr';
+import { catchError, tap } from 'rxjs/operators';
+import { Observable ,  of } from 'rxjs';
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot, Router } from '@angular/router';
+
+@Injectable()
+export class SearchResolver implements Resolve<any> {
+  appliedFilters: SearchParam = {...SearchingService.DEFAULT_FILTER};
+
+  constructor(
+    private searchingService: SearchingService,
+    private toastrService: ToastrService,
+    private router: Router
+  ) { }
+
+  resolve(route: ActivatedRouteSnapshot, _state: RouterStateSnapshot): Observable<any> {
+    const query = route.queryParams['q'];
+    const searchParams = {
+      ...this.appliedFilters,
+      q: query
+    };
+    return this.searchingService.search(searchParams).pipe(
+      catchError(_ => {
+        this.toastrService.error('', 'Bad search query');
+        this.router.navigate(['']);
+        return of({});
+      })
+    );
+  }
+}

--- a/src/app/modules/search/guards/search-resolver.ts
+++ b/src/app/modules/search/guards/search-resolver.ts
@@ -1,14 +1,14 @@
-import { SearchParam } from './../models/search-param';
+import { SearchAppliedParams } from './../models/search-param';
 import { SearchingService } from './../services/searching.service';
 import { ToastrService } from 'ngx-toastr';
-import { catchError, tap } from 'rxjs/operators';
+import { catchError } from 'rxjs/operators';
 import { Observable ,  of } from 'rxjs';
 import { Injectable } from '@angular/core';
 import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot, Router } from '@angular/router';
 
 @Injectable()
 export class SearchResolver implements Resolve<any> {
-  appliedFilters: SearchParam = {...SearchingService.DEFAULT_FILTER};
+  appliedFilters: SearchAppliedParams = SearchingService.DEFAULT_APPLIED_FILTERS;
 
   constructor(
     private searchingService: SearchingService,
@@ -18,11 +18,11 @@ export class SearchResolver implements Resolve<any> {
 
   resolve(route: ActivatedRouteSnapshot, _state: RouterStateSnapshot): Observable<any> {
     const query = route.queryParams['q'];
-    const searchParams = {
+    const appliedFilters = {
       ...this.appliedFilters,
       q: query
     };
-    return this.searchingService.search(searchParams).pipe(
+    return this.searchingService.search(appliedFilters).pipe(
       catchError(_ => {
         this.toastrService.error('', 'Bad search query');
         this.router.navigate(['']);

--- a/src/app/modules/search/guards/search-resolver.ts
+++ b/src/app/modules/search/guards/search-resolver.ts
@@ -17,7 +17,8 @@ export class SearchResolver implements Resolve<any> {
   ) { }
 
   resolve(route: ActivatedRouteSnapshot, _state: RouterStateSnapshot): Observable<any> {
-    const queryParams = this.searchingService.convertToAPISearchParams(route.queryParams);
+    const appliedParams = this.searchingService.convertToAppliedParams(route.queryParams);
+    const queryParams = this.searchingService.convertToAPISearchParams(appliedParams);
     return this.searchingService.search(queryParams).pipe(
       catchError(_ => {
         this.toastrService.error('', 'Bad search query');

--- a/src/app/modules/search/models/search-param.ts
+++ b/src/app/modules/search/models/search-param.ts
@@ -2,7 +2,7 @@ export interface SearchParam {
   q?: string;
   categories?: Array<string>;
   brands?: Array<string>;
-  filterOptions?: Array<FilterOption>;
+  filter_options?: Array<FilterOption>;
   sort?: string;
   page?: {
     limit?: string;
@@ -12,5 +12,5 @@ export interface SearchParam {
 
 export interface FilterOption {
   name: string;
-  value: string;
+  value: Array<string>;
 }

--- a/src/app/modules/search/models/search-param.ts
+++ b/src/app/modules/search/models/search-param.ts
@@ -1,8 +1,11 @@
+/**
+ * Allowed API parameters
+ *
+ * @export
+ * @interface SearchParam
+ */
 export interface SearchParam {
   q?: string;
-  categories?: Array<string>;
-  brands?: Array<string>;
-  filter_options?: Array<FilterOption>;
   f?: string;
   p?: string;
   rf?: string;
@@ -11,12 +14,21 @@ export interface SearchParam {
   o?: string;
 }
 
-export interface FilterOption {
-  name: string;
-  value: Array<string>;
+export interface FilterAgg {
+  id: string;
+  value: string;
+  count: string;
+  meta: string;
 }
 
+/**
+ * Applied Search params in angular components,
+ * which will be converted to API SearchParams
+ * @export
+ * @interface SearchAppliedParams
+ */
 export interface SearchAppliedParams {
+  q?: string;
   filters: Array<SearchFilter>;
   rangeFilters: Array<SearchFilter>;
   sort: string;

--- a/src/app/modules/search/models/search-param.ts
+++ b/src/app/modules/search/models/search-param.ts
@@ -29,9 +29,12 @@ export interface FilterAgg {
  */
 export interface SearchAppliedParams {
   q?: string;
-  filters: Array<SearchFilter>;
-  rangeFilters: Array<SearchFilter>;
-  sort: string;
+  filters?: Array<SearchFilter>;
+  rangeFilters?: Array<SearchFilter>;
+  sort?: string;
+  limit?: string;
+  offset?: string;
+  page?: string;
 }
 
 export interface SearchFilter {

--- a/src/app/modules/search/models/search-param.ts
+++ b/src/app/modules/search/models/search-param.ts
@@ -14,9 +14,16 @@ export interface SearchParam {
   o?: string;
 }
 
+// ex: {id: 'Color', {id: 'red', count: 100, meta: 'red'}}
+// ex: {id: 'Category', {id: 'tshirt', count: 100, meta: ''}}
 export interface FilterAgg {
+  id: string,
+  filterValues: Array<FilterValueAgg>
+}
+
+// ex: {id: 'red', count: 100, meta: 'red'}
+export interface FilterValueAgg {
   id: string;
-  value: string;
   count: string;
   meta: string;
 }

--- a/src/app/modules/search/models/search-param.ts
+++ b/src/app/modules/search/models/search-param.ts
@@ -3,14 +3,26 @@ export interface SearchParam {
   categories?: Array<string>;
   brands?: Array<string>;
   filter_options?: Array<FilterOption>;
+  f?: string;
+  p?: string;
+  rf?: string;
   sort?: string;
-  page?: {
-    limit?: string;
-    offset?: string;
-  }
+  rows?: string;
+  o?: string;
 }
 
 export interface FilterOption {
   name: string;
   value: Array<string>;
+}
+
+export interface SearchAppliedParams {
+  filters: Array<SearchFilter>;
+  rangeFilters: Array<SearchFilter>;
+  sort: string;
+}
+
+export interface SearchFilter {
+  id: string,
+  values: Array<string>;
 }

--- a/src/app/modules/search/pages/search-page/search-page.component.html
+++ b/src/app/modules/search/pages/search-page/search-page.component.html
@@ -6,7 +6,7 @@
     <app-search-title-container [metaInfo]="metaInfo"></app-search-title-container>
   </div>
   <div class="col pr-0 d-none d-sm-block verticalFilterContainer">
-    <app-search-filters-container [appliedFilters]="appliedFilters" [metaInfo]="metaInfo" (filterCleared)="clearFilters()" (filterUpdated)="updateFilters($event)"></app-search-filters-container>
+    <app-search-filters-container [appliedFilters]="appliedFilters" [metaInfo]="metaInfo" (filterCleared)="clearFilters()" (filterUpdated)="updateFilters($event)" (selectedAggregation)="selectAggregation($event)"></app-search-filters-container>
   </div>
   <div class="col">
     <div class="row d-none d-sm-flex">

--- a/src/app/modules/search/pages/search-page/search-page.component.html
+++ b/src/app/modules/search/pages/search-page/search-page.component.html
@@ -10,7 +10,7 @@
   </div>
   <div class="col">
     <div class="row d-none d-sm-flex">
-      <app-filter-summary-container class="col-12 pb-3 my-1" [appliedParams]="appliedParams" (updatedFilters)="updateFilters($event)"></app-filter-summary-container>
+      <app-filter-summary-container class="col-12 my-1" [appliedParams]="appliedParams" (updatedFilters)="updateFilters($event)"></app-filter-summary-container>
     </div>
     <app-search-results-container [searchResults]="searchResults"></app-search-results-container>
   </div>

--- a/src/app/modules/search/pages/search-page/search-page.component.html
+++ b/src/app/modules/search/pages/search-page/search-page.component.html
@@ -3,14 +3,14 @@
     <app-breadcrumbs [breadcrumbs]="breadcrumbs"></app-breadcrumbs>
   </div>
   <div class="col-12 mb-4">
-    <app-search-title-container [title]="appliedFilters.q || 'All Categories'" [metaInfo]="metaInfo"></app-search-title-container>
+    <app-search-title-container [title]="'All Categories'" [metaInfo]="metaInfo"></app-search-title-container>
   </div>
   <div class="col pr-0 d-none d-sm-block verticalFilterContainer">
-    <app-search-filters-container [appliedFilters]="appliedFilters" [metaInfo]="metaInfo" (filterCleared)="clearFilters()" (filterUpdated)="updateFilters($event)" (selectedAggregation)="selectAggregation($event)"></app-search-filters-container>
+    <app-search-filters-container [appliedParams]="appliedParams" [metaInfo]="metaInfo" (filterCleared)="clearFilters()" (filterUpdated)="updateFilters($event)" (selectedAggregation)="selectAggregation($event)"></app-search-filters-container>
   </div>
   <div class="col">
     <div class="row d-none d-sm-flex">
-      <app-filter-summary-container class="col-12 pb-3 my-1" [appliedFilters]="appliedFilters" (updatedFilters)="updateFilters($event)"></app-filter-summary-container>
+      <app-filter-summary-container class="col-12 pb-3 my-1" [appliedParams]="appliedParams" (updatedFilters)="updateFilters($event)"></app-filter-summary-container>
     </div>
     <app-search-results-container [searchResults]="searchResults"></app-search-results-container>
   </div>

--- a/src/app/modules/search/pages/search-page/search-page.component.html
+++ b/src/app/modules/search/pages/search-page/search-page.component.html
@@ -6,7 +6,7 @@
     <app-search-title-container [metaInfo]="metaInfo"></app-search-title-container>
   </div>
   <div class="col-2 pr-0 d-none d-sm-block">
-    <app-search-filters-container></app-search-filters-container>
+    <app-search-filters-container [metaInfo]="metaInfo"></app-search-filters-container>
   </div>
   <div class="col-12 col-md-10">
     <div class="row d-none d-sm-flex">

--- a/src/app/modules/search/pages/search-page/search-page.component.html
+++ b/src/app/modules/search/pages/search-page/search-page.component.html
@@ -1,4 +1,4 @@
-<section class="row search-container my-3 mx-auto">
+<section class="row search-container my-3 mx-auto" *ngIf="metaInfo" >
   <div class="col-12">
     <app-breadcrumbs></app-breadcrumbs>
   </div>

--- a/src/app/modules/search/pages/search-page/search-page.component.html
+++ b/src/app/modules/search/pages/search-page/search-page.component.html
@@ -5,10 +5,10 @@
   <div class="col-12 mb-4">
     <app-search-title-container [metaInfo]="metaInfo"></app-search-title-container>
   </div>
-  <div class="col-2 pr-0 d-none d-sm-block">
+  <div class="col pr-0 d-none d-sm-block verticalFilterContainer">
     <app-search-filters-container [metaInfo]="metaInfo"></app-search-filters-container>
   </div>
-  <div class="col-12 col-md-10">
+  <div class="col">
     <div class="row d-none d-sm-flex">
       <app-filter-summary-container class="col-12 pb-3 my-1" [appliedFilters]="appliedFilters" (updatedFilters)="filterUpdated($event)"></app-filter-summary-container>
     </div>

--- a/src/app/modules/search/pages/search-page/search-page.component.html
+++ b/src/app/modules/search/pages/search-page/search-page.component.html
@@ -3,13 +3,13 @@
     <app-breadcrumbs></app-breadcrumbs>
   </div>
   <div class="col-12 mb-4">
-    <app-search-title-container></app-search-title-container>
+    <app-search-title-container [metaInfo]="metaInfo"></app-search-title-container>
   </div>
-  <div class="col-2 pr-0">
+  <div class="col-2 pr-0 d-none d-sm-block">
     <app-search-filters-container></app-search-filters-container>
   </div>
-  <div class="col-10">
-    <div class="row">
+  <div class="col-12 col-md-10">
+    <div class="row d-none d-sm-flex">
       <app-filter-summary-container class="col-12 pb-3 my-1" [appliedFilters]="appliedFilters" (updatedFilters)="filterUpdated($event)"></app-filter-summary-container>
     </div>
     <app-search-results-container [searchResults]="searchResults"></app-search-results-container>

--- a/src/app/modules/search/pages/search-page/search-page.component.html
+++ b/src/app/modules/search/pages/search-page/search-page.component.html
@@ -6,11 +6,11 @@
     <app-search-title-container [metaInfo]="metaInfo"></app-search-title-container>
   </div>
   <div class="col pr-0 d-none d-sm-block verticalFilterContainer">
-    <app-search-filters-container [metaInfo]="metaInfo"></app-search-filters-container>
+    <app-search-filters-container [appliedFilters]="appliedFilters" [metaInfo]="metaInfo" (filterCleared)="clearFilters()" (filterUpdated)="updateFilters($event)"></app-search-filters-container>
   </div>
   <div class="col">
     <div class="row d-none d-sm-flex">
-      <app-filter-summary-container class="col-12 pb-3 my-1" [appliedFilters]="appliedFilters" (updatedFilters)="filterUpdated($event)"></app-filter-summary-container>
+      <app-filter-summary-container class="col-12 pb-3 my-1" [appliedFilters]="appliedFilters" (updatedFilters)="updateFilters($event)"></app-filter-summary-container>
     </div>
     <app-search-results-container [searchResults]="searchResults"></app-search-results-container>
   </div>

--- a/src/app/modules/search/pages/search-page/search-page.component.html
+++ b/src/app/modules/search/pages/search-page/search-page.component.html
@@ -1,9 +1,9 @@
 <section class="row search-container my-3 mx-auto" *ngIf="metaInfo" >
   <div class="col-12">
-    <app-breadcrumbs></app-breadcrumbs>
+    <app-breadcrumbs [breadcrumbs]="breadcrumbs"></app-breadcrumbs>
   </div>
   <div class="col-12 mb-4">
-    <app-search-title-container [metaInfo]="metaInfo"></app-search-title-container>
+    <app-search-title-container [title]="appliedFilters.q || 'All Categories'" [metaInfo]="metaInfo"></app-search-title-container>
   </div>
   <div class="col pr-0 d-none d-sm-block verticalFilterContainer">
     <app-search-filters-container [appliedFilters]="appliedFilters" [metaInfo]="metaInfo" (filterCleared)="clearFilters()" (filterUpdated)="updateFilters($event)" (selectedAggregation)="selectAggregation($event)"></app-search-filters-container>

--- a/src/app/modules/search/pages/search-page/search-page.component.scss
+++ b/src/app/modules/search/pages/search-page/search-page.component.scss
@@ -1,3 +1,7 @@
 .search-container {
   max-width: 1600px;
+  .verticalFilterContainer {
+    max-width: 250px;
+    min-width: 250px;
+  }
 }

--- a/src/app/modules/search/pages/search-page/search-page.component.ts
+++ b/src/app/modules/search/pages/search-page/search-page.component.ts
@@ -10,9 +10,7 @@ import { Product } from '../../../../core/models';
   styleUrls: ['./search-page.component.scss']
 })
 export class SearchPageComponent implements OnInit, OnDestroy {
-  appliedFilters: SearchParam = {
-    page: { limit: '20', offset: '1' }
-  };
+  appliedFilters: SearchParam = {...SearchingService.DEFAULT_FILTER};
   searchResults: Array<Product>;
   searchSubs$: Subscription;
   metaInfo: any;
@@ -25,7 +23,7 @@ export class SearchPageComponent implements OnInit, OnDestroy {
     this.search(this.appliedFilters);
   }
 
-  filterUpdated(updatedFilter: SearchParam) {
+  updateFilters(updatedFilter: SearchParam) {
     this.appliedFilters = updatedFilter;
     this.search(updatedFilter);
   }
@@ -42,6 +40,10 @@ export class SearchPageComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.searchSubs$.unsubscribe();
+  }
+
+  clearFilters() {
+    this.updateFilters({...SearchingService.DEFAULT_FILTER});
   }
 
 }

--- a/src/app/modules/search/pages/search-page/search-page.component.ts
+++ b/src/app/modules/search/pages/search-page/search-page.component.ts
@@ -76,4 +76,10 @@ export class SearchPageComponent implements OnInit, OnDestroy {
     this.selectedAggregation = aggregation;
   }
 
+  get breadcrumbs() {
+    return [
+      { crumb: this.appliedFilters.q || 'All Categories', link: '#'}
+    ]
+  }
+
 }

--- a/src/app/modules/search/pages/search-page/search-page.component.ts
+++ b/src/app/modules/search/pages/search-page/search-page.component.ts
@@ -4,7 +4,6 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { SearchParam, SearchAppliedParams } from '../../models/search-param';
 import { SearchingService } from '../../services';
 import { Product } from '../../../../core/models';
-import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'app-search-page',
@@ -15,6 +14,7 @@ export class SearchPageComponent implements OnInit, OnDestroy {
   appliedParams: SearchAppliedParams = SearchingService.DEFAULT_APPLIED_FILTERS;
   searchResults: Array<Product>;
   subsArray$: Array<Subscription> = [];
+  searchSubs$: Subscription;
   selectedAggregation: any;
   metaInfo: any;
 
@@ -34,7 +34,7 @@ export class SearchPageComponent implements OnInit, OnDestroy {
           this.metaInfo = meta;
         }),
       this.route.queryParams.subscribe((params: SearchParam) => {
-        // this.updateFilters(this.searchService.convertToAppliedParams(params));
+        this.updateFilters(this.searchService.convertToAppliedParams(params));
       })
     );
 
@@ -49,13 +49,12 @@ export class SearchPageComponent implements OnInit, OnDestroy {
 
   search(appliedParams: SearchAppliedParams) {
     const apiParams = this.searchService.convertToAPISearchParams(appliedParams);
-    this.subsArray$.push(
-      this.searchService.search(apiParams)
-        .subscribe(({ data, meta }) => {
-          this.searchResults = data;
-          this.metaInfo = meta;
-        })
-    );
+    if (this.searchSubs$) { this.searchSubs$.unsubscribe() }
+    this.searchSubs$ = this.searchService.search(apiParams)
+      .subscribe(({ data, meta }) => {
+        this.searchResults = [...data];
+        this.metaInfo = {...meta};
+      })
   }
 
   ngOnDestroy() {

--- a/src/app/modules/search/pages/search-page/search-page.component.ts
+++ b/src/app/modules/search/pages/search-page/search-page.component.ts
@@ -1,7 +1,7 @@
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { SearchParam } from '../../models/search-param';
+import { SearchParam, SearchAppliedParams } from '../../models/search-param';
 import { SearchingService } from '../../services';
 import { Product } from '../../../../core/models';
 import { map } from 'rxjs/operators';
@@ -12,7 +12,7 @@ import { map } from 'rxjs/operators';
   styleUrls: ['./search-page.component.scss']
 })
 export class SearchPageComponent implements OnInit, OnDestroy {
-  appliedParams: SearchParam = { ...SearchingService.DEFAULT_FILTER };
+  appliedParams: SearchAppliedParams = SearchingService.DEFAULT_APPLIED_FILTERS;
   searchResults: Array<Product>;
   searchSubs$: Subscription;
   selectedAggregation: any;
@@ -29,36 +29,27 @@ export class SearchPageComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.route.queryParams.subscribe((params: Object) => {
       this.updateFilters({
-        ...this.appliedParams,
-        ...params
+        ...this.appliedParams
       })
     });
 
     this.searchSubs$ = this.route.data
       .subscribe(({ resp: { data, meta } }) => {
         this.searchResults = data;
-        meta.aggregations.filters = {
-          ...meta.aggregations.filters,
-          ...this.selectedAggregation
-        }
         this.metaInfo = meta;
       });
   }
 
-  updateFilters(updatedFilter: SearchParam) {
-    this.appliedParams = updatedFilter;
-    this.search(updatedFilter);
+  updateFilters(appliedParams: SearchAppliedParams) {
+    this.appliedParams = appliedParams;
+    this.search(appliedParams);
   }
 
-  search(filterParams: SearchParam) {
+  search(appliedParams: SearchAppliedParams) {
     if (this.searchSubs$) { this.searchSubs$.unsubscribe() }
-    this.searchSubs$ = this.searchService.search(filterParams)
+    this.searchSubs$ = this.searchService.search(appliedParams)
       .subscribe(({ data, meta }) => {
         this.searchResults = data;
-        meta.aggregations.filters = {
-          ...meta.aggregations.filters,
-          ...this.selectedAggregation
-        }
         this.metaInfo = meta;
       });
   }
@@ -68,7 +59,7 @@ export class SearchPageComponent implements OnInit, OnDestroy {
   }
 
   clearFilters() {
-    this.updateFilters({ ...SearchingService.DEFAULT_FILTER });
+    this.updateFilters(SearchingService.DEFAULT_APPLIED_FILTERS);
     this.selectedAggregation = {};
   }
 

--- a/src/app/modules/search/pages/search-page/search-page.component.ts
+++ b/src/app/modules/search/pages/search-page/search-page.component.ts
@@ -12,7 +12,7 @@ import { map } from 'rxjs/operators';
   styleUrls: ['./search-page.component.scss']
 })
 export class SearchPageComponent implements OnInit, OnDestroy {
-  appliedFilters: SearchParam = { ...SearchingService.DEFAULT_FILTER };
+  appliedParams: SearchParam = { ...SearchingService.DEFAULT_FILTER };
   searchResults: Array<Product>;
   searchSubs$: Subscription;
   selectedAggregation: any;
@@ -29,7 +29,7 @@ export class SearchPageComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.route.queryParams.subscribe((params: Object) => {
       this.updateFilters({
-        ...this.appliedFilters,
+        ...this.appliedParams,
         ...params
       })
     });
@@ -46,7 +46,7 @@ export class SearchPageComponent implements OnInit, OnDestroy {
   }
 
   updateFilters(updatedFilter: SearchParam) {
-    this.appliedFilters = updatedFilter;
+    this.appliedParams = updatedFilter;
     this.search(updatedFilter);
   }
 
@@ -78,7 +78,7 @@ export class SearchPageComponent implements OnInit, OnDestroy {
 
   get breadcrumbs() {
     return [
-      { crumb: this.appliedFilters.q || 'All Categories', link: '#'}
+      { crumb: this.appliedParams.q || 'All Categories', link: '#'}
     ]
   }
 

--- a/src/app/modules/search/pages/search-page/search-page.component.ts
+++ b/src/app/modules/search/pages/search-page/search-page.component.ts
@@ -1,5 +1,5 @@
 import { Observable, Subscription } from 'rxjs';
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, OnDestroy } from '@angular/core';
 import { SearchParam } from '../../models/search-param';
 import { SearchingService } from '../../services';
 import { Product } from '../../../../core/models';
@@ -10,12 +10,13 @@ import { Product } from '../../../../core/models';
   // changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrls: ['./search-page.component.scss']
 })
-export class SearchPageComponent implements OnInit {
+export class SearchPageComponent implements OnInit, OnDestroy {
   appliedFilters: SearchParam = {
     page: { limit: '20', offset: '1' }
   };
   searchResults: Array<Product>;
   searchSubs$: Subscription;
+  metaInfo: any;
 
   constructor(
     private searchService: SearchingService
@@ -33,7 +34,15 @@ export class SearchPageComponent implements OnInit {
   search(filterParams: SearchParam) {
     if (this.searchSubs$) { this.searchSubs$.unsubscribe() }
     this.searchSubs$ = this.searchService.search(filterParams)
-      .subscribe(products => this.searchResults = [...products]);
+      .subscribe(resp => {
+        const {data, meta} = resp;
+        this.searchResults = data;
+        this.metaInfo = meta;
+      });
+  }
+
+  ngOnDestroy() {
+    this.searchSubs$.unsubscribe();
   }
 
 }

--- a/src/app/modules/search/pages/search-page/search-page.component.ts
+++ b/src/app/modules/search/pages/search-page/search-page.component.ts
@@ -1,5 +1,5 @@
-import { Observable, Subscription } from 'rxjs';
-import { Component, OnInit, ChangeDetectionStrategy, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { SearchParam } from '../../models/search-param';
 import { SearchingService } from '../../services';
 import { Product } from '../../../../core/models';
@@ -7,7 +7,6 @@ import { Product } from '../../../../core/models';
 @Component({
   selector: 'app-search-page',
   templateUrl: './search-page.component.html',
-  // changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrls: ['./search-page.component.scss']
 })
 export class SearchPageComponent implements OnInit, OnDestroy {

--- a/src/app/modules/search/pages/search-page/search-page.component.ts
+++ b/src/app/modules/search/pages/search-page/search-page.component.ts
@@ -27,11 +27,18 @@ export class SearchPageComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    this.route.queryParams.subscribe((params: Object) => {
+      this.updateFilters({
+        ...this.appliedFilters,
+        ...params
+      })
+    });
+
     this.searchSubs$ = this.route.data
-      .subscribe(({resp: { data, meta }}) => {
+      .subscribe(({ resp: { data, meta } }) => {
         this.searchResults = data;
-        meta.aggregations = {
-          ...meta.aggregations,
+        meta.aggregations.filters = {
+          ...meta.aggregations.filters,
           ...this.selectedAggregation
         }
         this.metaInfo = meta;
@@ -48,8 +55,8 @@ export class SearchPageComponent implements OnInit, OnDestroy {
     this.searchSubs$ = this.searchService.search(filterParams)
       .subscribe(({ data, meta }) => {
         this.searchResults = data;
-        meta.aggregations = {
-          ...meta.aggregations,
+        meta.aggregations.filters = {
+          ...meta.aggregations.filters,
           ...this.selectedAggregation
         }
         this.metaInfo = meta;

--- a/src/app/modules/search/search-routing.module.ts
+++ b/src/app/modules/search/search-routing.module.ts
@@ -1,3 +1,4 @@
+import { SearchResolver } from './guards/search-resolver';
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { SearchComponent } from './search.component';
@@ -7,7 +8,10 @@ const routes: Routes = [
   {
     path: '', component: SearchComponent,
     children: [
-      { path: '', component: SearchPageComponent }
+      {
+        path: '', component: SearchPageComponent,
+        resolve: { resp: SearchResolver }
+      }
     ]
   }
 ];

--- a/src/app/modules/search/search.module.ts
+++ b/src/app/modules/search/search.module.ts
@@ -1,3 +1,4 @@
+import { SearchResolver } from './guards/search-resolver';
 import { NgxInputStarRatingModule } from '@ngx-lite/input-star-rating';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
@@ -17,6 +18,9 @@ import { COMPONENTS } from './';
     NgxInputStarRatingModule,
 
     SharedModule
+  ],
+  providers: [
+    SearchResolver
   ]
 })
 export class SearchModule { }

--- a/src/app/modules/search/services/searching.service.ts
+++ b/src/app/modules/search/services/searching.service.ts
@@ -32,21 +32,23 @@ export class SearchingService {
 
   search(appliedParams: SearchAppliedParams) {
     return this.http
-      .post<{ data: Array<Product>, links: any, meta: any }>(
+      .get<{ data: Array<Product>, links: any, meta: any }>(
         `api/v1/products`,
         {
-          ...this.convertToAPISearchParams(appliedParams),
-          ...this.pageData
+          params: this.convertToAPISearchParams(appliedParams)
+            .set('o', '0')
+            .set('p', '1')
         }
       );
   }
 
-  convertToAPISearchParams({ sort, filters, rangeFilters }: SearchAppliedParams) {
-    return {
-      f: this.stringifySearchFilter(filters),
-      rf: this.stringifySearchFilter(rangeFilters),
-      sort: sort
-    }
+  convertToAPISearchParams({ sort, filters, rangeFilters, q }: SearchAppliedParams): HttpParams {
+    return new HttpParams()
+      .set('f', this.stringifySearchFilter(filters))
+      .set('rf', this.stringifySearchFilter(rangeFilters))
+      .set('sort', sort)
+      .set('rows', '50')
+      .set('q', q || '')
   }
 
   private stringifySearchFilter(searchFilter: Array<SearchFilter>) {

--- a/src/app/modules/search/services/searching.service.ts
+++ b/src/app/modules/search/services/searching.service.ts
@@ -21,7 +21,7 @@ export class SearchingService {
     private http: HttpClient,
   ) { }
 
-  search(searchParams: SearchParam): Observable<Array<Product>> {
-    return this.http.post<Array<Product>>(`api/v1/products`, searchParams);
+  search(searchParams: SearchParam) {
+    return this.http.post<{data: Array<Product>, links: any, meta: any}>(`api/v1/products`, searchParams);
   }
 }

--- a/src/app/modules/search/services/searching.service.ts
+++ b/src/app/modules/search/services/searching.service.ts
@@ -9,6 +9,10 @@ import { SortFilter } from '../models/sort-filter';
   providedIn: 'root'
 })
 export class SearchingService {
+  static DEFAULT_FILTER = {
+    page: { limit: '20', offset: '1' }
+  };
+
   static SORT_CONFIG: Array<SortFilter> = [
     { name: 'Recommended', value: '', default: true },
     { name: 'Price: High to Low', value: 'price-desc-rank' },

--- a/src/app/modules/search/services/searching.service.ts
+++ b/src/app/modules/search/services/searching.service.ts
@@ -10,7 +10,8 @@ import { SortFilter } from '../models/sort-filter';
 })
 export class SearchingService {
   static DEFAULT_FILTER = {
-    page: { limit: '20', offset: '1' }
+    rows: '50',
+    o: '0'
   };
 
   static SORT_CONFIG: Array<SortFilter> = [

--- a/src/app/modules/search/services/searching.service.ts
+++ b/src/app/modules/search/services/searching.service.ts
@@ -87,7 +87,7 @@ export class SearchingService {
 
     Object.keys(params)
       .filter(param => params[param])
-      .map(param => newParam = {...newParam, [param]: params[param]})
+      .map(param => newParam = { ...newParam, [param]: params[param] })
 
     return newParam;
   }

--- a/src/app/shared/components/breadcrumbs/breadcrumbs.component.html
+++ b/src/app/shared/components/breadcrumbs/breadcrumbs.component.html
@@ -2,7 +2,7 @@
   <ol class="breadcrumb bg-transparent pl-0 mb-0">
     <li class="breadcrumb-item" [ngClass]="{'active': lastCrumb}" *ngFor="let breadcrumb of breadcrumbs; last as lastCrumb">
       <a *ngIf="!lastCrumb" class="text-secondary" [routerLink]="breadcrumb.link">{{breadcrumb.crumb}}</a>
-      <span *ngIf="lastCrumb" class="font-weight-bold text-dark">{{breadcrumb.crumb}}</span>
+      <span *ngIf="lastCrumb" class="font-weight-bold text-dark text-capitalize">{{breadcrumb.crumb}}</span>
     </li>
   </ol>
 </nav>

--- a/src/app/shared/components/breadcrumbs/breadcrumbs.component.ts
+++ b/src/app/shared/components/breadcrumbs/breadcrumbs.component.ts
@@ -1,16 +1,30 @@
 import { Component, OnInit, Input } from '@angular/core';
 
+const DefaultCrumb = [
+  { crumb: 'Home', link: '/' },
+];
+
+interface BreadCrumb {
+  crumb: string;
+  link: string;
+}
+
 @Component({
   selector: 'app-breadcrumbs',
   templateUrl: './breadcrumbs.component.html',
   styleUrls: ['./breadcrumbs.component.scss']
 })
 export class BreadcrumbsComponent implements OnInit {
-  @Input() breadcrumbs: {crumb: string, link: string}[] = [
-    {crumb: 'This', link: '#'},
-    {crumb: 'is', link: '#'},
-    {crumb: 'Placehoder', link: '#'}
-  ];
+  _breadcrumbs: Array<BreadCrumb> = [];
+
+  get breadcrumbs(): Array<BreadCrumb> {
+    return [...DefaultCrumb, ...this._breadcrumbs];
+  }
+
+  @Input('breadcrumbs')
+  set breadcrumbs(value: Array<BreadCrumb>) {
+    this._breadcrumbs = value || [];
+  }
 
   constructor() { }
 

--- a/src/app/shared/components/breadcrumbs/breadcrumbs.component.ts
+++ b/src/app/shared/components/breadcrumbs/breadcrumbs.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 
 @Component({
   selector: 'app-breadcrumbs',
@@ -6,10 +6,10 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./breadcrumbs.component.scss']
 })
 export class BreadcrumbsComponent implements OnInit {
-  breadcrumbs: {crumb: string, link: string}[] = [
-    {crumb: 'Home', link: '#'},
-    {crumb: 'Category', link: '#'},
-    {crumb: 'Data', link: '#'}
+  @Input() breadcrumbs: {crumb: string, link: string}[] = [
+    {crumb: 'This', link: '#'},
+    {crumb: 'is', link: '#'},
+    {crumb: 'Placehoder', link: '#'}
   ];
 
   constructor() { }

--- a/src/app/user/services/user.service.ts
+++ b/src/app/user/services/user.service.ts
@@ -24,7 +24,7 @@ export class UserService {
    * @memberof UserService
    */
   getOrders(): Observable<Array<Order>> {
-    return this.http.get<Array<Order>>(`api/v1/orders`);
+    return this.http.get<{data: Array<Order>}>(`api/v1/orders`).pipe(map(resp => resp.data));
   }
 
   /**
@@ -37,7 +37,7 @@ export class UserService {
    */
   getOrderDetail(orderNumber: string): Observable<Order> {
     const url = `api/v1/orders/${orderNumber}`;
-    return this.http.get<Order>(url);
+    return this.http.get<{data: Order}>(url).pipe(map(resp => resp.data));
   }
 
   /**
@@ -49,11 +49,11 @@ export class UserService {
    */
   getUser(): Observable<User> {
     const user_id = isPlatformBrowser(this.platformId) ? JSON.parse(localStorage.getItem('user')).id : null;
-    return this.http.get<User>(`api/v1/users/${user_id}`);
+    return this.http.get<{data: User}>(`api/v1/users/${user_id}`).pipe(map(resp => resp.data));
   }
 
   updateUser(params: any): Observable<User> {
-    return this.http.put<User>(`api/v1/users/${params.user_id}`, params);
+    return this.http.put<{data: User}>(`api/v1/users/${params.user_id}`, params).pipe(map(resp => resp.data));
   }
 
   updateUserPassword(params: any) {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -106,4 +106,7 @@ $l-max: 90;
 
 .pointer {
   cursor: pointer;
+  &:focus {
+    outline: none;
+  }
 }


### PR DESCRIPTION
### Why?
- Integrate search response and aggregation with the filters.
- Integrate search with search router.
- JSON API params missing after deserialisation.

### This addresses the need by :  
- Creates a `search API parameter` `interface` used for API calls.
- Creates a `search Applied Parameters` `interface` for component level search parameters.
- Integrates aggregation with filters with there counts and meta info.
- JsonAPI deserializer sends data with all other params as sibling.

### Pending : -
- selected filter summary cross button not working.
- Page flickers when clicking filter.
- Page UI not optimised for change detection will require ngrx integration.