### PR TITLE
Range filter fix

### DIFF
--- a/src/app/modules/search/components/search-filters-container/components/range-filter/range-filter.component.html
+++ b/src/app/modules/search/components/search-filters-container/components/range-filter/range-filter.component.html
@@ -1,6 +1,6 @@
 <ul class="list-group border border-left-0 border-bottom-0 py-3">
   <small class="font-weight-bold pb-3 text-uppercase">{{filter.id}}</small>
-  <li class="list-group-item border-0 p-0 pr-1">
-    <ng5-slider [(value)]="filter.min" [(highValue)]="filter.max" (userChangeEnd)="filterUpdated($event)"></ng5-slider>
+  <li class="list-group-item custom-slider border-0 p-0 pr-1">
+    <ng5-slider [(value)]="minValue" [(highValue)]="maxValue" [options]="options" (userChangeEnd)="filterUpdated($event)"></ng5-slider>
   </li>
 </ul>

--- a/src/app/modules/search/components/search-filters-container/components/range-filter/range-filter.component.scss
+++ b/src/app/modules/search/components/search-filters-container/components/range-filter/range-filter.component.scss
@@ -1,0 +1,48 @@
+::ng-deep {
+  .custom-slider .ng5-slider .ng5-slider-bar {
+    background: #f8d1d0;
+    height: 2px;
+  }
+  .custom-slider .ng5-slider .ng5-slider-selection {
+    background: #e18582;
+  }
+
+  .custom-slider .ng5-slider .ng5-slider-pointer {
+    width: 11px;
+    height: 11px;
+    border-radius: 100px;
+    top: auto;
+    bottom: -2px;
+    background-color: #ffffff;
+    box-shadow: 0 0px 3px 0px #c96360;
+    &:focus {
+      outline: none;
+    }
+  }
+
+  .custom-slider .ng5-slider .ng5-slider-pointer:after {
+    display: none;
+  }
+
+  .custom-slider .ng5-slider .ng5-slider-bubble {
+    bottom: 14px;
+  }
+
+  .custom-slider .ng5-slider .ng5-slider-limit {
+    font-weight: bold;
+    color: orange;
+  }
+
+  .custom-slider .ng5-slider .ng5-slider-tick {
+    width: 1px;
+    height: 10px;
+    margin-left: 4px;
+    border-radius: 0;
+    background: #ffe4d1;
+    top: -1px;
+  }
+
+  .custom-slider .ng5-slider .ng5-slider-tick.ng5-slider-selected {
+    background: orange;
+  }
+}

--- a/src/app/modules/search/components/search-filters-container/components/range-filter/range-filter.component.ts
+++ b/src/app/modules/search/components/search-filters-container/components/range-filter/range-filter.component.ts
@@ -1,3 +1,4 @@
+import { SearchFilter } from './../../../../models/search-param';
 import { Options, LabelType } from 'ng5-slider';
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { RangeAgg } from '../../../../models/search-param';
@@ -11,16 +12,35 @@ export class RangeFilterComponent implements OnInit {
   @Input() filter: RangeAgg;
   @Input() symbol: string;
   @Output() rangeSeleted = new EventEmitter<string>();
+  @Input() appliedFilters: Array<SearchFilter>;
+  minValue = 0;
+  maxValue = 100;
   options: Options = {
     floor: 0,
+    ceil: 100,
     translate: (value: number, _: LabelType): string => {
-      return this.symbol + value;
+      return `${this.symbol || ''} ${value}`;
     }
   };
 
   constructor() { }
 
   ngOnInit() {
+    this.options = Object.assign({}, this.options, {
+      ceil: this.filter.max
+    });
+
+    const currentFilter = this.appliedFilters
+      .find(filter => filter.id === this.filter.id);
+
+    if (currentFilter) {
+      const [min, max] = currentFilter.values[0].split(' TO ');
+      this.minValue = parseInt(min, 10);
+      this.maxValue = parseInt(max, 10);
+    } else {
+      this.minValue = this.filter.min;
+      this.maxValue = this.filter.max;
+    }
   }
 
   filterUpdated(event: { value: number; highValue: number; }) {

--- a/src/app/modules/search/components/search-filters-container/components/single-selection-filter/single-selection-filter.component.html
+++ b/src/app/modules/search/components/search-filters-container/components/single-selection-filter/single-selection-filter.component.html
@@ -1,10 +1,10 @@
 <ul class="list-group border border-left-0 border-bottom-0 py-3" *ngIf="showFilter">
-  <small class="font-weight-bold pb-3 text-uppercase">{{filter.name}}</small>
-  <li *ngFor="let item of filter.items | slice: skipCount" class="list-group-item border-0 p-0">
-    <div class="custom-control custom-radio">
-      <input type="radio" class="custom-control-input" id="{{item.value}}">
-      <label class="custom-control-label text-capitalize" for="{{item.value}}">{{item.name}}</label>
-      <small class="text-secondary font-weight-light"> ( {{item.count}} ) </small>
+  <small class="font-weight-bold pb-3 text-uppercase">{{filter.id}}</small>
+  <li *ngFor="let filterValue of filter.values | slice: skipCount;" class="list-group-item border-0 p-0">
+    <div class="custom-control custom-checkbox">
+      <input type="radio" class="custom-control-input" id="{{filterValue.id}}" [ngModel]="isSelected(filterValue.id)" (change)="selectedItem(filterValue.id)">
+      <label class="custom-control-label text-capitalize" for="{{filterValue.id}}">{{filterValue.id}}</label>
+      <small class="text-secondary font-weight-light"> ( {{filterValue.count}} ) </small>
     </div>
   </li>
 </ul>

--- a/src/app/modules/search/components/search-filters-container/search-filters-container.component.html
+++ b/src/app/modules/search/components/search-filters-container/search-filters-container.component.html
@@ -10,5 +10,5 @@
 </div>
 
 <div *ngFor="let filter of rangeFilters">
-  <app-range-filter [filter]="filter" (rangeSeleted)="updateRangeFilter($event, filter.id)"></app-range-filter>
+  <app-range-filter [appliedFilters]="appliedParams.rangeFilters" [filter]="filter" (rangeSeleted)="updateRangeFilter($event, filter.id)"></app-range-filter>
 </div>


### PR DESCRIPTION
### Why?
- Range filter boundaries cannot be reverted back once selected.
- Due to the API returning the range boundaries depending on the params.

### This change addresses the need by:
- Uses the API's max range value, irrespective of what was selected.
- Fixes the issue with the options integration for ng5-slider.
- Adds custom CSS override for ng5-slider