### PR TITLE
Fixes for ordersuccess page & details page

### DIFF
--- a/src/app/checkout/payment/services/payment.service.ts
+++ b/src/app/checkout/payment/services/payment.service.ts
@@ -47,7 +47,8 @@ export class PaymentService {
   makeCodPayment(orderId: number): Observable<Order> {
     const params = this.buildCodPaymentJson(orderId);
     const url = `api/v1/payment/cod_payment`
-    return this.http.post<Order>(url, params);
+    return this.http.post<{data: Order}>(url, params)
+    .pipe(map(res => res.data));
   }
 
   makeStripePayment(cardToken: any, orderNumber: string, paymentId: string, orderAmount: number, paymentMethodId: number,

--- a/src/app/core/models/line_item.ts
+++ b/src/app/core/models/line_item.ts
@@ -1,10 +1,5 @@
 import { Variant } from './variant';
 import { Product } from './product';
-/*
- * LineItem model
- * Detailed info http://guides.spreecommerce.org/developer/orders.html#line-items
- * Public API's http://guides.spreecommerce.org/api/line_items.html
- */
 
 export class LineItem {
   id: number;

--- a/src/app/core/models/product.ts
+++ b/src/app/core/models/product.ts
@@ -37,4 +37,5 @@ export class Product {
   is_orderable: boolean;
   brand: {name: string, id: number};
   discount: number;
+  default_image:  { default_product_url: string};
 }

--- a/src/app/user/components/orders/order-detail/order-detail.component.html
+++ b/src/app/user/components/orders/order-detail/order-detail.component.html
@@ -15,11 +15,10 @@
           <td>Item price:</td>
           <td>{{currency}} {{order.order_total_amount.amount}}</td>
         </tr>
-        <tr>
-        <tr>
+        <!-- <tr>
           <td>Shipping:</td>
           <td>{{currency}} 0.00</td>
-        </tr>
+        </tr> -->
         <tr>
           <td>Total Amount:</td>
           <td> {{currency}} {{order.order_total_amount.amount}} </td>

--- a/src/app/user/components/orders/order-detail/order-detail.component.ts
+++ b/src/app/user/components/orders/order-detail/order-detail.component.ts
@@ -53,8 +53,8 @@ export class OrderDetailComponent implements OnInit, OnDestroy {
   }
 
   getProductImageUrl(line_item: LineItem) {
-    const imageUrl = line_item.product.images[0];
-    return imageUrl ? imageUrl.product_url : this.noImageUrl;
+    const imageUrl = line_item.product.default_image;
+    return imageUrl ? imageUrl.default_product_url : this.noImageUrl;
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
## Why?
* COD order success page was displayed after order placement.
* Line items image were not displayed on order details page.
## This change addresses the need by:
* Order success page now displayed after COD order placement. 
* Line items images now displayed.
* Modified service/component to accept changed API response.